### PR TITLE
feat: JWT 발급, 인증 인가, 최종 회원가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'com.h2database:h2'
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/econovation/moongtaengi/MoongtaengiApplication.java
+++ b/src/main/java/econovation/moongtaengi/MoongtaengiApplication.java
@@ -1,5 +1,6 @@
 package econovation.moongtaengi;
 
+import econovation.moongtaengi.global.security.config.JwtConfig;
 import econovation.moongtaengi.member.infrastructure.oauth.config.KakaoConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -8,7 +9,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
-@EnableConfigurationProperties(KakaoConfig.class)
+@EnableConfigurationProperties(
+		{KakaoConfig.class, JwtConfig.class})
 public class MoongtaengiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/econovation/moongtaengi/global/exception/ErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/global/exception/ErrorCode.java
@@ -16,6 +16,11 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_001", "존재하지 않는 회원입니다."),
     ALREADY_REGISTERED(HttpStatus.CONFLICT, "MEMBER_002", "이미 회원가입이 완료된 회원입니다."),
 
+    // JWT 인증
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "만료된 토큰입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_003", "인증이 필요합니다."),
+
     // 공통
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COMMON_001", "잘못된 입력값입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_002", "서버 내부 오류가 발생했습니다.");

--- a/src/main/java/econovation/moongtaengi/global/security/CustomAuthentication.java
+++ b/src/main/java/econovation/moongtaengi/global/security/CustomAuthentication.java
@@ -1,0 +1,56 @@
+package econovation.moongtaengi.global.security;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+/**
+ * JWT 인증 전용 Authentication
+ * 단순히 memberId만 저장
+ */
+public class CustomAuthentication implements Authentication {
+
+    private final Long memberId;
+    private boolean authenticated;
+
+    public CustomAuthentication(Long memberId) {
+        this.memberId = memberId;
+        this.authenticated = true;
+    }
+
+    @Override
+    public Long getPrincipal() {
+        return memberId;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return authenticated;
+    }
+
+    @Override
+    public void setAuthenticated(boolean authenticated) {
+        this.authenticated = authenticated;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();  // 권한 없음
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;  // 비밀번호 없음
+    }
+
+    @Override
+    public Object getDetails() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(memberId);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/global/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/econovation/moongtaengi/global/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,45 @@
+package econovation.moongtaengi.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import econovation.moongtaengi.global.exception.ErrorCode;
+import econovation.moongtaengi.global.exception.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+/**
+ * 인증 실패 시 처리
+ * 인증되지 않은 사용자가 보호된 리소스에 접근할 때 호출
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+
+        log.warn("인증 실패 - URI: {}, Message: {}",
+                request.getRequestURI(), authException.getMessage());
+
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.UNAUTHORIZED);
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/econovation/moongtaengi/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/econovation/moongtaengi/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,62 @@
+package econovation.moongtaengi.global.security;
+
+import econovation.moongtaengi.global.security.exception.ExpiredTokenException;
+import econovation.moongtaengi.global.security.exception.InvalidTokenException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        try {
+            String token = resolveToken(request);
+
+            if (StringUtils.hasText(token)) {
+                jwtTokenProvider.validateToken(token);
+                Long memberId = jwtTokenProvider.getMemberId(token);
+
+                CustomAuthentication authentication = new CustomAuthentication(memberId);
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                log.debug("JWT 인증 성공 - memberId: {}, URI: {}", memberId, request.getRequestURI());
+            }
+
+        } catch (InvalidTokenException | ExpiredTokenException e) {
+            log.warn("JWT 인증 실패: {} - URI: {}", e.getMessage(), request.getRequestURI());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/econovation/moongtaengi/global/security/JwtTokenProvider.java
+++ b/src/main/java/econovation/moongtaengi/global/security/JwtTokenProvider.java
@@ -1,0 +1,86 @@
+package econovation.moongtaengi.global.security;
+
+import econovation.moongtaengi.global.security.config.JwtConfig;
+import econovation.moongtaengi.global.security.exception.ExpiredTokenException;
+import econovation.moongtaengi.global.security.exception.InvalidTokenException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey secretKey;
+    private final long accessTokenValidityMs;
+
+    public JwtTokenProvider(JwtConfig jwtConfig) {
+        this.secretKey = Keys.hmacShaKeyFor(jwtConfig.secret().getBytes(StandardCharsets.UTF_8));
+        this.accessTokenValidityMs = jwtConfig.accessTokenValidity();
+        log.info("JwtTokenProvider 초기화 완료 - 만료시간: {}ms ({}분)",
+                accessTokenValidityMs, accessTokenValidityMs / 60000);
+    }
+
+    public String createAccessToken(Long memberId) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + accessTokenValidityMs);
+
+        String token = Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .issuedAt(now)
+                .expiration(validity)
+                .signWith(secretKey)
+                .compact();
+
+        log.debug("AccessToken 생성 - memberId: {}, 만료: {}", memberId, validity);
+        return token;
+    }
+
+    public Long getMemberId(String token) {
+        try {
+            Claims claims = parseClaims(token);
+            return Long.parseLong(claims.getSubject());
+        } catch (NumberFormatException e) {
+            log.error("memberId 파싱 실패: {}", token);
+            throw new InvalidTokenException();
+        }
+    }
+
+    public void validateToken(String token) {
+        try {
+            parseClaims(token);
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 JWT 토큰: {}", e.getMessage());
+            throw new ExpiredTokenException();
+        } catch (UnsupportedJwtException e) {
+            log.warn("지원되지 않는 JWT 토큰: {}", e.getMessage());
+            throw new InvalidTokenException();
+        } catch (MalformedJwtException e) {
+            log.warn("잘못된 JWT 토큰: {}", e.getMessage());
+            throw new InvalidTokenException();
+        } catch (SignatureException e) {
+            log.warn("JWT 서명 검증 실패: {}", e.getMessage());
+            throw new InvalidTokenException();
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT 토큰이 비어있음: {}", e.getMessage());
+            throw new InvalidTokenException();
+        }
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/econovation/moongtaengi/global/security/config/JwtConfig.java
+++ b/src/main/java/econovation/moongtaengi/global/security/config/JwtConfig.java
@@ -1,0 +1,10 @@
+package econovation.moongtaengi.global.security.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtConfig(
+        String secret,
+        Long accessTokenValidity
+) {
+}

--- a/src/main/java/econovation/moongtaengi/global/security/config/SecurityConfig.java
+++ b/src/main/java/econovation/moongtaengi/global/security/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                         // 인증 불필요 (public)
                         .requestMatchers(
                                 "/api/auth/kakao/callback",
+                                "/api/members/check-nickname",
                                 "/h2-console/**",
                                 "/error"
                         ).permitAll()

--- a/src/main/java/econovation/moongtaengi/global/security/config/SecurityConfig.java
+++ b/src/main/java/econovation/moongtaengi/global/security/config/SecurityConfig.java
@@ -1,0 +1,63 @@
+package econovation.moongtaengi.global.security.config;
+
+import econovation.moongtaengi.global.security.JwtAuthenticationEntryPoint;
+import econovation.moongtaengi.global.security.JwtAuthenticationFilter;
+import econovation.moongtaengi.global.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * Spring Security 설정
+ */
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+
+                .authorizeHttpRequests(authorize -> authorize
+                        // 인증 불필요 (public)
+                        .requestMatchers(
+                                "/api/auth/kakao/callback",
+                                "/h2-console/**",
+                                "/error"
+                        ).permitAll()
+
+                        // 나머지는 인증 필요
+                        .anyRequest().authenticated()
+                )
+
+                .exceptionHandling(exception ->
+                        exception.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                )
+
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class
+                );
+
+        // h2 페이지 오류 해결 용도
+        http.headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()));
+
+        return http.build();
+    }
+}

--- a/src/main/java/econovation/moongtaengi/global/security/exception/ExpiredTokenException.java
+++ b/src/main/java/econovation/moongtaengi/global/security/exception/ExpiredTokenException.java
@@ -1,0 +1,14 @@
+package econovation.moongtaengi.global.security.exception;
+
+import econovation.moongtaengi.global.exception.BusinessException;
+import econovation.moongtaengi.global.exception.ErrorCode;
+
+/**
+ * 만료된 JWT 토큰 예외
+ */
+public class ExpiredTokenException extends BusinessException {
+
+    public ExpiredTokenException() {
+        super(ErrorCode.EXPIRED_TOKEN);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/global/security/exception/InvalidTokenException.java
+++ b/src/main/java/econovation/moongtaengi/global/security/exception/InvalidTokenException.java
@@ -1,0 +1,14 @@
+package econovation.moongtaengi.global.security.exception;
+
+import econovation.moongtaengi.global.exception.BusinessException;
+import econovation.moongtaengi.global.exception.ErrorCode;
+
+/**
+ * 유효하지 않은 JWT 토큰 예외
+ */
+public class InvalidTokenException extends BusinessException {
+
+    public InvalidTokenException() {
+        super(ErrorCode.INVALID_TOKEN);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/member/api/AuthController.java
+++ b/src/main/java/econovation/moongtaengi/member/api/AuthController.java
@@ -33,19 +33,14 @@ public class AuthController {
     }
 
     private String buildRedirectUrl(KakaoLoginResponse response) {
-        // 임시 회원
-        if (response.needsAdditionalInfo()) {
-            return UriComponentsBuilder
-                    .fromUriString(frontendRedirectUri + "/signup")
-                    .queryParam("memberId", response.memberId())
-                    .build()
-                    .toUriString();
-        }
 
-        // 기존 회원
+        String path = response.needsAdditionalInfo()
+                ? "/signup"
+                : "/";
+
         return UriComponentsBuilder
-                .fromUriString(frontendRedirectUri + "/")
-                .queryParam("memberId", response.memberId())
+                .fromUriString(frontendRedirectUri + path)
+                .queryParam("token", response.accessToken())
                 .build()
                 .toUriString();
     }

--- a/src/main/java/econovation/moongtaengi/member/api/MemberController.java
+++ b/src/main/java/econovation/moongtaengi/member/api/MemberController.java
@@ -1,16 +1,24 @@
 package econovation.moongtaengi.member.api;
 
+import econovation.moongtaengi.member.api.dto.CompleteRegistrationRequest;
 import econovation.moongtaengi.member.api.dto.NicknameCheckResponse;
 import econovation.moongtaengi.member.application.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
@@ -35,4 +43,19 @@ public class MemberController {
                 NicknameCheckResponse.unavailable(nickname, e.getMessage())
         );
     }
+
+    @PostMapping("/me/complete-registration")
+    public ResponseEntity<Void> completeRegistration(
+            @Valid @RequestBody CompleteRegistrationRequest request
+    ) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        Long memberId = (Long) auth.getPrincipal();
+
+        memberService.completeRegistration(memberId, request.nickname());
+
+        log.info("회원가입 완료 API 호출 성공 - memberId: {}", memberId);
+
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/econovation/moongtaengi/member/api/dto/CompleteRegistrationRequest.java
+++ b/src/main/java/econovation/moongtaengi/member/api/dto/CompleteRegistrationRequest.java
@@ -1,0 +1,11 @@
+package econovation.moongtaengi.member.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CompleteRegistrationRequest(
+    @NotBlank(message = "닉네임은 필수입니다")
+    @Size(min = 2, max = 7, message = "닉네임은 2자 이상 7자 이하여야 합니다")
+    String nickname
+) {
+}

--- a/src/main/java/econovation/moongtaengi/member/application/AuthService.java
+++ b/src/main/java/econovation/moongtaengi/member/application/AuthService.java
@@ -1,5 +1,6 @@
 package econovation.moongtaengi.member.application;
 
+import econovation.moongtaengi.global.security.JwtTokenProvider;
 import econovation.moongtaengi.member.infrastructure.oauth.KakaoOAuthClient;
 import econovation.moongtaengi.member.domain.Member;
 import econovation.moongtaengi.member.domain.MemberRepository;
@@ -13,8 +14,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AuthService {
+
     private final MemberRepository memberRepository;
     private final KakaoOAuthClient kakaoOAuthClient;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
     public KakaoLoginResponse loginWithKakao(String code) {
@@ -25,8 +28,13 @@ public class AuthService {
         Member member = memberRepository.findByKakaoId(kakaoId)
                 .orElseGet(() -> createTemporaryMember(kakaoId));
 
+        String accessToken = jwtTokenProvider.createAccessToken(member.getId());
+
+        log.info("로그인 성공 - memberId: {}, needsInfo: {}",
+                member.getId(), member.isTemporary());
+
         return new KakaoLoginResponse(
-                member.getId(),
+                accessToken,
                 member.isTemporary()
         );
     }
@@ -39,7 +47,7 @@ public class AuthService {
     }
 
     public record KakaoLoginResponse(
-            Long memberId,
+            String accessToken,
             boolean needsAdditionalInfo  // true면 추가정보 입력 페이지로 이동
     ) {}
 }

--- a/src/main/java/econovation/moongtaengi/member/application/MemberService.java
+++ b/src/main/java/econovation/moongtaengi/member/application/MemberService.java
@@ -1,15 +1,38 @@
 package econovation.moongtaengi.member.application;
 
+import econovation.moongtaengi.member.domain.Member;
+import econovation.moongtaengi.member.domain.MemberRepository;
+import econovation.moongtaengi.member.domain.Nickname;
 import econovation.moongtaengi.member.domain.NicknameFactory;
+import econovation.moongtaengi.member.exception.MemberNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberService {
+
+    private final MemberRepository memberRepository;
     private final NicknameFactory nicknameFactory;
 
     public void checkNicknameAvailability(String nickname) {
         nicknameFactory.createNickname(nickname);
+    }
+
+    @Transactional
+    public void completeRegistration(Long memberId, String nicknameValue) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        Nickname nickname = nicknameFactory.createNickname(nicknameValue);
+
+        member.completeRegistration(nickname);
+
+        log.info("최종 회원가입 완료 - memberId: {}, nickname: {}",
+                memberId, nickname.getValue());
     }
 }

--- a/src/main/java/econovation/moongtaengi/member/domain/Member.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/Member.java
@@ -1,6 +1,7 @@
 package econovation.moongtaengi.member.domain;
 
 import econovation.moongtaengi.global.entity.BaseEntity;
+import econovation.moongtaengi.member.exception.AlreadyRegisteredException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -32,6 +33,18 @@ public class Member extends BaseEntity {
         member.kakaoId = kakaoId;
         member.status = MemberStatus.TEMPORARY;
         return member;
+    }
+
+    public void completeRegistration(Nickname nickname) {
+        validateCanComplete();
+        this.nickname = nickname;
+        this.status = MemberStatus.ACTIVE;
+    }
+
+    private void validateCanComplete() {
+        if (this.status == MemberStatus.ACTIVE) {
+            throw new AlreadyRegisteredException();
+        }
     }
 
     public boolean isTemporary() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,3 +36,6 @@ oauth:
     token-uri: https://kauth.kakao.com/oauth/token
     user-info-uri: https://kapi.kakao.com/v2/user/me
 
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-validity: 1800000


### PR DESCRIPTION
### 📌 PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [X] 코드 리팩토링
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈

### 🧑‍💻 구현한 내용
1. JWT 인증 시스템 구현
- JWT 토큰 생성 및 검증
  - JwtTokenProvider: JWT 생성, 검증, memberId 추출
JwtConfig: JWT 설정 관리 (@ConfigurationProperties)
AccessToken 만료시간: 30분
환경변수로 JWT Secret 관리 (.env)

- JWT 인증 필터
  - JwtAuthenticationFilter: Authorization 헤더에서 JWT 추출 및 검증
CustomAuthentication: 간소화된 인증 객체 (memberId만 포함)
SecurityContext에 인증 정보 저장

- Spring Security 설정
  - SecurityConfig: JWT 기반 Stateless 인증 설정
CSRF 비활성화, 세션 미사용
인증 불필요 엔드포인트: /api/auth/kakao/callback, /api/members/check-nickname, /h2-console/**
인증 필요 엔드포인트: 나머지 모든 API

2. 카카오 로그인 JWT 발급
- AuthService 수정
  - 카카오 로그인 성공 시 JWT 생성
KakaoLoginResponse에 accessToken 포함 (memberId → accessToken)
임시회원/기존회원 여부 반환 (needsAdditionalInfo)

- AuthController 수정
  - 프론트엔드로 redirect 시 JWT를 쿼리 파라미터로 전달
URL 형식: /signup/?token=eyJhbGc...
기존회원: /?token=eyJhbGc...


3. 회원가입 완료 API 구현
- Member 도메인 수정
  - completeRegistration(Nickname) 메서드 추가
회원가입 완료 검증 로직 (TEMPORARY → ACTIVE)

- MemberService 구현
  - completeRegistration(): 회원가입 완료 로직
회원가입 완료 시 최종 중복 검증 (Race Condition 방지)
Member 상태 변경 (TEMPORARY → ACTIVE)

- MemberController 추가
  - POST `/api/members/me/complete-registration`: 회원가입 완료 API
JWT 인증 필요
SecurityContext에서 memberId 추출

- DTO 추가
  - CompleteRegistrationRequest: 회원가입 완료 요청 DTO
nickname 필수, 2~7자 검증 (@Valid)

### 🧪 테스트 결과

### 👿 트러블 슈팅

### 💬 코멘트
PR 좀 분리했어야 했는데,, 지환님이랑 코드 겹치는 부분 없을거 같아서 JWT 발급 및 인증 인가 코드 구현이랑
최종 회원가입 API까지 한번에 했습니다.
Race Condition 방지하기 위해서 최종 회원가입 API 요청 보내면 닉네임 중복 검사 한번 더 하게 했어요 !
그리고 로그인 성공 시 리다이렉트 하는 부분 코드 기존보다 보기 편하게 리팩토링 해뒀습니다

