### PR TITLE
feat: 스터디 도메인 모델링 및 비즈니스 로직 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/member/domain/Nickname.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/Nickname.java
@@ -21,7 +21,7 @@ public class Nickname {
     @Column(name = "nickname", unique = true)
     private String value;
 
-    Nickname(String value) {
+    public Nickname(String value) {
         validate(value);
         this.value = value;
     }

--- a/src/main/java/econovation/moongtaengi/member/domain/Nickname.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/Nickname.java
@@ -21,7 +21,7 @@ public class Nickname {
     @Column(name = "nickname", unique = true)
     private String value;
 
-    public Nickname(String value) {
+    Nickname(String value) {
         validate(value);
         this.value = value;
     }

--- a/src/main/java/econovation/moongtaengi/study/domain/Study.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/Study.java
@@ -1,9 +1,13 @@
 package econovation.moongtaengi.study.domain;
 
 import econovation.moongtaengi.global.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,7 +20,16 @@ public class Study extends BaseEntity {
     @Embedded
     StudyName name;
 
-    public Study(StudyName name) {
+    @OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<StudyMember> members = new ArrayList<>();
+
+    public Study(StudyName name, Long hostId) {
         this.name = name;
+        addMember(hostId, StudyRole.HOST); //스터디를 생성한 사람은 방장
+    }
+
+    public void addMember(Long memberId, StudyRole studyRole) {
+        StudyMember studyMember = new StudyMember(this, memberId, studyRole);
+        members.add(studyMember);
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/domain/Study.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/Study.java
@@ -1,0 +1,22 @@
+package econovation.moongtaengi.study.domain;
+
+import econovation.moongtaengi.global.entity.BaseEntity;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "studies")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Study extends BaseEntity {
+    @Embedded
+    StudyName name;
+
+    public Study(StudyName name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyFactory.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyFactory.java
@@ -1,0 +1,22 @@
+package econovation.moongtaengi.study.domain;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StudyFactory {
+    private final StudyRepository studyRepository;
+
+    public Study createStudy(Long memberId, String rawName) {
+        int hostedCount = studyRepository.countByMemberIdAndRole(memberId, StudyRole.HOST);
+
+        if (hostedCount >= 5) {
+            throw new IllegalArgumentException("스터디는 최대 5개까지만 생성 가능합니다.");
+        }
+
+        StudyName studyName = new StudyName(rawName);
+
+        return new Study(studyName, memberId);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyMember.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyMember.java
@@ -1,0 +1,37 @@
+package econovation.moongtaengi.study.domain;
+
+import econovation.moongtaengi.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_members")
+public class StudyMember extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_id")
+    private Study study;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private StudyRole role;
+
+    public StudyMember(Study study, Long memberId, StudyRole role) {
+        this.study = study;
+        this.memberId = memberId;
+        this.role = role;
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyName.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyName.java
@@ -1,0 +1,42 @@
+package econovation.moongtaengi.study.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyName {
+    private static final int MIN_LENGTH = 2;
+    private static final int MAX_LENGTH = 10;
+    private static final Pattern PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9\\s]+$");
+
+    @Column(name = "name", nullable = false)
+    private String value;
+
+    public StudyName(String value) {
+        String trimmed = (value != null) ? value.trim() : null;
+        validate(trimmed);
+        this.value = trimmed;
+    }
+
+    private void validate(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("스터디 이름은 비어있을 수 없습니다.");
+        }
+
+        if (value.length() < MIN_LENGTH || value.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("스터디 이름은 " + MIN_LENGTH + "자 이상 " + MAX_LENGTH + "자 이하여야 합니다.");
+        }
+
+        if (!PATTERN.matcher(value).matches()) {
+            throw new IllegalArgumentException("스터디 이름의 형식이 올바르지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyRepository.java
@@ -1,0 +1,10 @@
+package econovation.moongtaengi.study.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface StudyRepository extends JpaRepository<Study, Long> {
+    @Query("select count(s) from Study s join s.members m where m.memberId = :memberId and m.role = :role")
+    int countByMemberIdAndRole(@Param("memberId") Long memberId, @Param("role") StudyRole role);
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyRole.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyRole.java
@@ -1,0 +1,6 @@
+package econovation.moongtaengi.study.domain;
+
+public enum StudyRole {
+    HOST,
+    GUEST
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyFactoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyFactoryTest.java
@@ -1,0 +1,55 @@
+package econovation.moongtaengi.study.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class StudyFactoryTest {
+    @Mock
+    private StudyRepository studyRepository;
+
+    @InjectMocks
+    private StudyFactory studyFactory;
+
+    @Test
+    @DisplayName("내가 방장인 스터디가 5개 미만이면, 새 스터디 생성에 성공한다")
+    void 스터디_생성_성공() {
+        // given
+        Long hostId = 1L;
+        String studyName = "스프링 스터디";
+        given(studyRepository.countByMemberIdAndRole(eq(hostId), eq(StudyRole.HOST)))
+                .willReturn(4);
+
+        // when
+        Study study = studyFactory.createStudy(hostId, studyName);
+
+        // then
+        assertThat(study).isNotNull();
+        assertThat(study.getName().getValue()).isEqualTo(studyName);
+        assertThat(study.getMembers()).hasSize(1);
+        assertThat(study.getMembers().get(0).getMemberId()).isEqualTo(hostId);
+    }
+
+    @Test
+    @DisplayName("내가 방장인 스터디가 이미 5개라면, 예외가 발생한다")
+    void 스터디_생성_제한_실패() {
+        // given
+        Long hostId = 1L;
+        given(studyRepository.countByMemberIdAndRole(eq(hostId), eq(StudyRole.HOST)))
+                .willReturn(5);
+
+        // when & then
+        assertThatThrownBy(() -> studyFactory.createStudy(hostId, "새 스터디"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("5개까지만");
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyNameTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyNameTest.java
@@ -1,0 +1,81 @@
+package econovation.moongtaengi.study.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class StudyNameTest {
+    @Test
+    @DisplayName("정상적인 스터디 이름은 생성된다 (한글, 영어, 숫자, 공백 허용)")
+    void 스터디이름_생성_성공() {
+        // given
+        String validName = "Sp링 스터디 1기";
+
+        // when
+        StudyName studyName = new StudyName(validName);
+
+        // then
+        assertThat(studyName.getValue()).isEqualTo(validName);
+    }
+
+    @Test
+    @DisplayName("앞뒤 공백은 자동으로 제거되어 저장된다")
+    void 스터디이름_공백제거_테스트() {
+        // given
+        String untrimmedName = "  뭉탱이  ";
+
+        // when
+        StudyName studyName = new StudyName(untrimmedName);
+
+        // then
+        assertThat(studyName.getValue()).isEqualTo("뭉탱이");
+    }
+
+    @Test
+    @DisplayName("스터디 이름은 null이거나 비어있을 수 없다")
+    void 스터디이름_null_빈값_체크() {
+        //given
+        String nullValue = null;
+        String blankValue = "   ";
+
+        //when&then
+        assertThatThrownBy(() -> new StudyName(nullValue))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("스터디 이름은 비어있을 수 없습니다.");
+
+        assertThatThrownBy(() -> new StudyName(blankValue))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("스터디 이름은 비어있을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("스터디 이름 길이는 2자 이상 10자 이하여야 한다")
+    void 스터디이름_길이_체크() {
+        //given
+        String shortName = "A";
+        String longName = "뭉탱이탱이탱이탱이탱이탱이";
+
+        //when&then
+        assertThatThrownBy(() -> new StudyName(shortName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("2자 이상");
+
+        assertThatThrownBy(() -> new StudyName(longName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("10자 이하");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Study!", "뭉탱이@", "#코딩"}) //given
+    @DisplayName("특수문자가 포함되면 예외가 발생한다")
+    void 스터디이름_형식_체크(String invalidValue) {
+        //when&then
+        assertThatThrownBy(() -> new StudyName(invalidValue))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("스터디 이름의 형식이 올바르지 않습니다.");
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyTest.java
@@ -1,0 +1,23 @@
+package econovation.moongtaengi.study.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class StudyTest {
+    @Test
+    @DisplayName("스터디 생성 시 이름이 올바르게 설정된다")
+    void 스터디_생성_성공() {
+        // given
+        StudyName name = new StudyName("스프링 스터디");
+
+        // when
+        Study study = new Study(name);
+
+        // then
+        assertThat(study).isNotNull();
+        assertThat(study.getName()).isEqualTo(name);
+    }
+}
+

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyTest.java
@@ -7,17 +7,20 @@ import org.junit.jupiter.api.Test;
 
 public class StudyTest {
     @Test
-    @DisplayName("스터디 생성 시 이름이 올바르게 설정된다")
+    @DisplayName("스터디 생성 시 이름이 올바르게 설정되고, 생성자가 방장으로 등록된다.")
     void 스터디_생성_성공() {
         // given
         StudyName name = new StudyName("스프링 스터디");
+        Long hostId = 1L;
 
         // when
-        Study study = new Study(name);
+        Study study = new Study(name, hostId);
 
         // then
         assertThat(study).isNotNull();
         assertThat(study.getName()).isEqualTo(name);
+        assertThat(study.getMembers()).hasSize(1);
+        assertThat(study.getMembers().get(0).getMemberId()).isEqualTo(hostId);
     }
 }
 


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
1. Domain
- Study:
   - 생성 시 생성자(Host)를 멤버로 자동 등록하는 로직을 포함
- StudyMember:
   - 스터디와 회원의 연관 관계를 담당하며, `Role` (HOST/GUEST) 상태를 가짐
   - 같은 애그리거트인 `Study`는 객체로 참조하고, 다른 애그리거트인 Member는 ID로 느슨하게 참조
- StudyName (Value Object):
   - `@Embeddable`을 사용하여 값 객체로 정의
   - 생성 시 `trim()` 처리 및 길이/형식 검증 로직을 내장
- StudyRepository:
   - 팩토리의 검증 로직을 위해 `countByMemberIdAndRole` 쿼리 메서드를 추가

2. Domain Service 
- StudyFactory:
   - 복잡한 생성 로직을 캡슐화하기 위해 팩토리 도입
   - 비즈니스 규칙: "멤버는 방장으로서 최대 5개의 스터디만 생성할 수 있다"는 규칙을 검사한 후 객체를 생성

3. Test 
- StudyNameTest: 공백 제거, 길이 제한, 정규식 검증 테스트
- StudyTest: 스터디 생성 시 방장이 정상적으로 등록되는지 검증
- StudyFactoryTest: Mockito를 활용하여 5개 생성 제한 규칙이 정상 동작하는지 검증
### 🧪 테스트 결과
아직 API는 없어서 Postman을 통한 테스트는 못하고 테스트 코드를 통해서만 테스트 진행했습니다!
### 👿 트러블 슈팅
트러블 슈팅은 아니고... 팩토리를 가지는 객체의 생성자의 접근 제어를 public 으로 해야할지 default로 해야할지 좀 많이 고민했습니다..
default로 하면 개발자 실수를 막는다는 장점이 있는데 테스트 코드 작성할 때 많이 번거롭다는 단점이 있어서 public으로 두었습니다.
### 💬 코멘트
예외들이 IllegalArgumentException으로 되어 있는데 Nickname 예외 적용하면서 함께 커스텀 예외로 다 만들도록 하겠습니다!
아 그리고 스터디명은 2~10글자 제한 뒀고 한글/영어/숫자/띄어쓰기 가능하도록 했습니다. 이 부분은 회의 때 함께 의논해보면 좋을 것 같아요!

