### PR TITLE
feat: 스터디 기간(StudyPeriod) 및 주제(StudyTopic) 도메인 모델 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/domain/Study.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/Study.java
@@ -23,12 +23,16 @@ public class Study extends BaseEntity {
     @Embedded
     StudyPeriod period;
 
+    @Embedded
+    StudyTopic topic;
+
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StudyMember> members = new ArrayList<>();
 
-    public Study(StudyName name, StudyPeriod period, Long hostId) {
+    public Study(StudyName name, StudyPeriod period, StudyTopic topic, Long hostId) {
         this.name = name;
         this.period = period;
+        this.topic = topic;
         addMember(hostId, StudyRole.HOST); //스터디를 생성한 사람은 방장
     }
 

--- a/src/main/java/econovation/moongtaengi/study/domain/Study.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/Study.java
@@ -20,11 +20,15 @@ public class Study extends BaseEntity {
     @Embedded
     StudyName name;
 
+    @Embedded
+    StudyPeriod period;
+
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StudyMember> members = new ArrayList<>();
 
-    public Study(StudyName name, Long hostId) {
+    public Study(StudyName name, StudyPeriod period, Long hostId) {
         this.name = name;
+        this.period = period;
         addMember(hostId, StudyRole.HOST); //스터디를 생성한 사람은 방장
     }
 

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyFactory.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyFactory.java
@@ -9,7 +9,11 @@ import org.springframework.stereotype.Component;
 public class StudyFactory {
     private final StudyRepository studyRepository;
 
-    public Study createStudy(Long memberId, String rawName, LocalDate startDate, LocalDate endDate) {
+    public Study createStudy(Long memberId,
+            String rawName,
+            LocalDate startDate,
+            LocalDate endDate,
+            String topic) {
         int hostedCount = studyRepository.countByMemberIdAndRole(memberId, StudyRole.HOST);
 
         if (hostedCount >= 5) {
@@ -18,7 +22,8 @@ public class StudyFactory {
 
         StudyName studyName = new StudyName(rawName);
         StudyPeriod studyPeriod = new StudyPeriod(startDate, endDate);
+        StudyTopic studyTopic = new StudyTopic(topic);
 
-        return new Study(studyName, studyPeriod, memberId);
+        return new Study(studyName, studyPeriod, studyTopic, memberId);
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyFactory.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyFactory.java
@@ -1,5 +1,6 @@
 package econovation.moongtaengi.study.domain;
 
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -8,7 +9,7 @@ import org.springframework.stereotype.Component;
 public class StudyFactory {
     private final StudyRepository studyRepository;
 
-    public Study createStudy(Long memberId, String rawName) {
+    public Study createStudy(Long memberId, String rawName, LocalDate startDate, LocalDate endDate) {
         int hostedCount = studyRepository.countByMemberIdAndRole(memberId, StudyRole.HOST);
 
         if (hostedCount >= 5) {
@@ -16,7 +17,8 @@ public class StudyFactory {
         }
 
         StudyName studyName = new StudyName(rawName);
+        StudyPeriod studyPeriod = new StudyPeriod(startDate, endDate);
 
-        return new Study(studyName, memberId);
+        return new Study(studyName, studyPeriod, memberId);
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyPeriod.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyPeriod.java
@@ -1,0 +1,51 @@
+package econovation.moongtaengi.study.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class StudyPeriod {
+    private static final int MIN_TOTAL_DAYS = 1;
+    private static final int MAX_TOTAL_DAYS = 730;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    public StudyPeriod(LocalDate startDate, LocalDate endDate) {
+        validate(startDate, endDate);
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public long getTotalDays() {
+        return ChronoUnit.DAYS.between(startDate, endDate) + 1;
+    }
+
+    private void validate(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null) {
+            throw new IllegalArgumentException("시작일과 종료일은 필수입니다.");
+        }
+
+        if (endDate.isBefore(startDate)) {
+            throw new IllegalArgumentException("종료일이 시작일보다 앞에 있을 수 없습니다.");
+        }
+
+        long days = ChronoUnit.DAYS.between(startDate, endDate) + 1;
+
+        if (days < MIN_TOTAL_DAYS || days > MAX_TOTAL_DAYS) {
+            throw new IllegalArgumentException("기간은 " + MIN_TOTAL_DAYS + " 이상 " + MAX_TOTAL_DAYS + " 이하여야 합니다.");
+        }
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyTopic.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyTopic.java
@@ -1,0 +1,35 @@
+package econovation.moongtaengi.study.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyTopic {
+    private static final int MAX_LENGTH = 50;
+
+    @Column(name = "topic", nullable = false)
+    private String value;
+
+    public StudyTopic(String value) {
+        String trimmed = (value != null) ? value.trim() : null;
+        validate(trimmed);
+        this.value = trimmed;
+    }
+
+    private void validate(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("스터디 주제는 필수입니다.");
+        }
+
+        if (value.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("스터디 주제는 최대 " + MAX_LENGTH + "자까지만 가능합니다.");
+        }
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyFactoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyFactoryTest.java
@@ -29,11 +29,12 @@ public class StudyFactoryTest {
         String studyName = "스프링 스터디";
         LocalDate start = LocalDate.now();
         LocalDate end = start.plusDays(7);
+        String topic = "스프링부트 JPA";
         given(studyRepository.countByMemberIdAndRole(eq(hostId), eq(StudyRole.HOST)))
                 .willReturn(4);
 
         // when
-        Study study = studyFactory.createStudy(hostId, studyName, start, end);
+        Study study = studyFactory.createStudy(hostId, studyName, start, end, topic);
 
         // then
         assertThat(study).isNotNull();
@@ -49,11 +50,12 @@ public class StudyFactoryTest {
         Long hostId = 1L;
         LocalDate start = LocalDate.now();
         LocalDate end = start.plusDays(7);
+        String topic = "스프링부트 JPA";
         given(studyRepository.countByMemberIdAndRole(eq(hostId), eq(StudyRole.HOST)))
                 .willReturn(5);
 
         // when & then
-        assertThatThrownBy(() -> studyFactory.createStudy(hostId, "새 스터디", start, end))
+        assertThatThrownBy(() -> studyFactory.createStudy(hostId, "새 스터디", start, end, topic))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("5개까지만");
     }

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyFactoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyFactoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
+import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,11 +27,13 @@ public class StudyFactoryTest {
         // given
         Long hostId = 1L;
         String studyName = "스프링 스터디";
+        LocalDate start = LocalDate.now();
+        LocalDate end = start.plusDays(7);
         given(studyRepository.countByMemberIdAndRole(eq(hostId), eq(StudyRole.HOST)))
                 .willReturn(4);
 
         // when
-        Study study = studyFactory.createStudy(hostId, studyName);
+        Study study = studyFactory.createStudy(hostId, studyName, start, end);
 
         // then
         assertThat(study).isNotNull();
@@ -44,11 +47,13 @@ public class StudyFactoryTest {
     void 스터디_생성_제한_실패() {
         // given
         Long hostId = 1L;
+        LocalDate start = LocalDate.now();
+        LocalDate end = start.plusDays(7);
         given(studyRepository.countByMemberIdAndRole(eq(hostId), eq(StudyRole.HOST)))
                 .willReturn(5);
 
         // when & then
-        assertThatThrownBy(() -> studyFactory.createStudy(hostId, "새 스터디"))
+        assertThatThrownBy(() -> studyFactory.createStudy(hostId, "새 스터디", start, end))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("5개까지만");
     }

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyPeriodTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyPeriodTest.java
@@ -1,0 +1,81 @@
+package econovation.moongtaengi.study.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class StudyPeriodTest {
+    @Test
+    @DisplayName("정상적인 기간(1 이상 730 이하)은 생성된다")
+    void 기간_생성_성공() {
+        // given
+        LocalDate start = LocalDate.of(2025, 12, 1);
+        LocalDate end = LocalDate.of(2025, 12, 31);
+
+        // when
+        StudyPeriod period = new StudyPeriod(start, end);
+
+        // then
+        assertThat(period.getTotalDays()).isEqualTo(31);
+    }
+
+    @Test
+    @DisplayName("시작일과 종료일이 같아도(1일) 생성된다")
+    void 당일치기_생성_성공() {
+        // given
+        LocalDate date = LocalDate.of(2025, 12, 1);
+
+        // when
+        StudyPeriod period = new StudyPeriod(date, date);
+
+        // then
+        assertThat(period.getTotalDays()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("시작일이나 종료일이 null이면 예외가 발생한다")
+    void 기간_Null_체크() {
+        //given
+        LocalDate now = LocalDate.now();
+        LocalDate nullDate = null;
+
+        //when&then
+        assertThatThrownBy(() -> new StudyPeriod(nullDate, now))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("시작일과 종료일은 필수입니다.");
+
+        assertThatThrownBy(() -> new StudyPeriod(now, nullDate))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("시작일과 종료일은 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("종료일이 시작일보다 빠르면 예외가 발생한다")
+    void 날짜_순서_체크() {
+        // given
+        LocalDate start = LocalDate.of(2025, 12, 1);
+        LocalDate end = LocalDate.of(2025, 11, 1);
+
+        // when & then
+        assertThatThrownBy(() -> new StudyPeriod(start, end))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("종료일이 시작일보다 앞에 있을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("기간이 730일을 초과하면 예외가 발생한다")
+    void 최대_기간_체크() {
+        // given
+        LocalDate start = LocalDate.of(2023, 1, 1);
+        LocalDate end = start.plusDays(730); // 731일째 (1일 초과)
+
+        // when & then
+        assertThatThrownBy(() -> new StudyPeriod(start, end))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("730 이하");
+    }
+
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyTest.java
@@ -13,10 +13,11 @@ public class StudyTest {
         // given
         StudyName name = new StudyName("스프링 스터디");
         StudyPeriod period = new StudyPeriod(LocalDate.now(), LocalDate.now().plusDays(7));
+        StudyTopic topic = new StudyTopic("스프링부트 JPA");
         Long hostId = 1L;
 
         // when
-        Study study = new Study(name, period, hostId);
+        Study study = new Study(name, period, topic, hostId);
 
         // then
         assertThat(study).isNotNull();

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyTest.java
@@ -2,6 +2,7 @@ package econovation.moongtaengi.study.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -11,10 +12,11 @@ public class StudyTest {
     void 스터디_생성_성공() {
         // given
         StudyName name = new StudyName("스프링 스터디");
+        StudyPeriod period = new StudyPeriod(LocalDate.now(), LocalDate.now().plusDays(7));
         Long hostId = 1L;
 
         // when
-        Study study = new Study(name, hostId);
+        Study study = new Study(name, period, hostId);
 
         // then
         assertThat(study).isNotNull();

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyTopicTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyTopicTest.java
@@ -1,0 +1,55 @@
+package econovation.moongtaengi.study.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class StudyTopicTest {
+    @Test
+    @DisplayName("정상적인 주제는 생성된다")
+    void 주제_생성_성공() {
+        StudyTopic topic = new StudyTopic("스프링 부트");
+        assertThat(topic.getValue()).isEqualTo("스프링 부트");
+    }
+
+    @Test
+    @DisplayName("주제의 앞뒤 공백은 제거된다")
+    void 주제_공백_제거() {
+        //given
+        String untrimmed = "   JPA    ";
+
+        //when
+        StudyTopic topic = new StudyTopic(untrimmed);
+
+        //then
+        assertThat(topic.getValue()).isEqualTo("JPA");
+    }
+
+    @Test
+    @DisplayName("주제가 비어있으면 예외가 발생한다")
+    void 주제_빈값_체크() {
+        //given
+        String nullValue = null;
+        String blankValue = "   ";
+
+        //when&then
+        assertThatThrownBy(() -> new StudyTopic(nullValue))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("필수");
+
+        assertThatThrownBy(() -> new StudyTopic(blankValue))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("필수");
+    }
+
+    @Test
+    @DisplayName("주제가 50자를 넘으면 예외가 발생한다")
+    void 주제_길이_체크() {
+        String longTopic = "1234567890123456789011238746178236478126348716238471623874612387461412341234231123412341234123412341234321";
+        assertThatThrownBy(() -> new StudyTopic(longTopic))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("50자");
+    }
+}


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
1. Domain Layer 
- StudyPeriod (VO) 구현:
   - 기간 검증: 시작일과 종료일의 순서(`start <= end`) 및 유효 기간(1일~730일) 검증 로직 내장
   - 로직 캡슐화: DB에 별도의 컬럼을 두지 않고, `getTotalDays()` 메서드를 통해 기간을 계산하도록 설계
- StudyTopic (VO) 구현:
   - 데이터 정제: 입력값의 앞뒤 공백을 자동으로 제거(`trim`)하여 저장하도록 구현
   - 유효성 검증: 필수값(`null/blank`) 체크 및 길이 제한(최대 50자) 로직 적용
- Study (Aggregate Root):
   - `period`, `topic` 필드를 `@Embedded` 타입으로 추가
- StudyFactory (Domain Service):
   - 팩토리 내부에서 VO 생성함으로써, 잘못된 입력값이 들어오면 객체 조립 전에 예외가 발생하도록 구현

2. Test 
- Unit Test 추가:
   - `StudyPeriodTest`: 날짜 순서 위반, 최소/최대 기간 제한, 당일치기 등 케이스 검증
   - `StudyTopicTest`: 공백 제거(trim) 동작 확인, 빈 값 및 길이 초과 예외 검증
- 기존 테스트 업데이트:
   - `StudyFactoryTest`, `StudyTest`에 변경된 생성자 및 팩토리 시그니처 반영
### 🧪 테스트 결과
아직 API가 없어서 Postman을 통한 테스틑 하지 못했고 테스트 코드 다 돌렸을 때 통과했습니다!
### 👿 트러블 슈팅

### 💬 코멘트
스터디 제목 같은 경우는 특수문자 제외시켰는데...스터디 주제는 특수문자 같은 것 제외를 안했습니다.. 스터디 제목이랑 스터디 주제 형식 어느 정도까지 가능하게 할지 의논해봐야할 것 같아요!


