### PR TITLE
refactor: 전역 에러 처리 구조 개편 및 닉네임, 스터디 커스텀 예외 적용

### DIFF
--- a/src/main/java/econovation/moongtaengi/global/exception/BusinessException.java
+++ b/src/main/java/econovation/moongtaengi/global/exception/BusinessException.java
@@ -15,4 +15,9 @@ public class BusinessException extends RuntimeException {
         super(errorCode.getMessage(), cause);
         this.errorCode = errorCode;
     }
+
+    public BusinessException(ErrorCode errorCode, Object ... args) {
+        super(String.format(errorCode.getMessage(), args));
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/econovation/moongtaengi/global/exception/ErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/global/exception/ErrorCode.java
@@ -4,28 +4,8 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
-@Getter
-@RequiredArgsConstructor
-public enum ErrorCode {
-
-    // 카카오 OAuth 관련
-    KAKAO_AUTH_FAILED(HttpStatus.UNAUTHORIZED, "KAKAO_001", "카카오 인증에 실패했습니다."),
-    KAKAO_SERVER_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "KAKAO_002", "카카오 서버에 오류가 발생했습니다."),
-
-    // 회원 관련
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_001", "존재하지 않는 회원입니다."),
-    ALREADY_REGISTERED(HttpStatus.CONFLICT, "MEMBER_002", "이미 회원가입이 완료된 회원입니다."),
-
-    // JWT 인증
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "유효하지 않은 토큰입니다."),
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "만료된 토큰입니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_003", "인증이 필요합니다."),
-
-    // 공통
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COMMON_001", "잘못된 입력값입니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_002", "서버 내부 오류가 발생했습니다.");
-
-    private final HttpStatus status;
-    private final String code;
-    private final String message;
+public interface ErrorCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
 }

--- a/src/main/java/econovation/moongtaengi/global/exception/GlobalErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/global/exception/GlobalErrorCode.java
@@ -1,0 +1,16 @@
+package econovation.moongtaengi.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COMMON_001", "잘못된 입력값입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_002", "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/econovation/moongtaengi/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/econovation/moongtaengi/global/exception/GlobalExceptionHandler.java
@@ -24,10 +24,10 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         log.error("예상치 못한 오류 발생", e);
 
-        ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        ErrorResponse response = ErrorResponse.of(GlobalErrorCode.INTERNAL_SERVER_ERROR);
 
         return ResponseEntity
-                .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .status(GlobalErrorCode.INTERNAL_SERVER_ERROR.getStatus())
                 .body(response);
     }
 }

--- a/src/main/java/econovation/moongtaengi/global/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/econovation/moongtaengi/global/security/JwtAuthenticationEntryPoint.java
@@ -3,6 +3,7 @@ package econovation.moongtaengi.global.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import econovation.moongtaengi.global.exception.ErrorCode;
 import econovation.moongtaengi.global.exception.ErrorResponse;
+import econovation.moongtaengi.global.security.exception.AuthErrorCode;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -35,7 +36,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         log.warn("인증 실패 - URI: {}, Message: {}",
                 request.getRequestURI(), authException.getMessage());
 
-        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.UNAUTHORIZED);
+        ErrorResponse errorResponse = ErrorResponse.of(AuthErrorCode.UNAUTHORIZED);
 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/econovation/moongtaengi/global/security/exception/AuthErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/global/security/exception/AuthErrorCode.java
@@ -1,0 +1,18 @@
+package econovation.moongtaengi.global.security.exception;
+
+import econovation.moongtaengi.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode  implements ErrorCode {
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "만료된 토큰입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_003", "인증이 필요합니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/econovation/moongtaengi/global/security/exception/ExpiredTokenException.java
+++ b/src/main/java/econovation/moongtaengi/global/security/exception/ExpiredTokenException.java
@@ -9,6 +9,6 @@ import econovation.moongtaengi.global.exception.ErrorCode;
 public class ExpiredTokenException extends BusinessException {
 
     public ExpiredTokenException() {
-        super(ErrorCode.EXPIRED_TOKEN);
+        super(AuthErrorCode.EXPIRED_TOKEN);
     }
 }

--- a/src/main/java/econovation/moongtaengi/global/security/exception/InvalidTokenException.java
+++ b/src/main/java/econovation/moongtaengi/global/security/exception/InvalidTokenException.java
@@ -9,6 +9,6 @@ import econovation.moongtaengi.global.exception.ErrorCode;
 public class InvalidTokenException extends BusinessException {
 
     public InvalidTokenException() {
-        super(ErrorCode.INVALID_TOKEN);
+        super(AuthErrorCode.INVALID_TOKEN);
     }
 }

--- a/src/main/java/econovation/moongtaengi/member/api/MemberController.java
+++ b/src/main/java/econovation/moongtaengi/member/api/MemberController.java
@@ -3,6 +3,7 @@ package econovation.moongtaengi.member.api;
 import econovation.moongtaengi.member.api.dto.CompleteRegistrationRequest;
 import econovation.moongtaengi.member.api.dto.NicknameCheckResponse;
 import econovation.moongtaengi.member.application.MemberService;
+import econovation.moongtaengi.member.domain.NicknameException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,21 +28,12 @@ public class MemberController {
 
     @GetMapping("/check-nickname")
     public ResponseEntity<NicknameCheckResponse> checkNickname(@RequestParam("nickname") String nickname) {
-        memberService.checkNicknameAvailability(nickname);
-
-        return ResponseEntity.ok(NicknameCheckResponse.available(nickname));
-    }
-
-    @ExceptionHandler(IllegalArgumentException.class) //예외처리기 PR 머지 후 커스텀 예외 클래스로 변경 예정
-    public ResponseEntity<NicknameCheckResponse> handleIllegalArgumentException(
-            IllegalArgumentException e,
-            HttpServletRequest request
-    ) {
-        String nickname = request.getParameter("nickname");
-
-        return ResponseEntity.ok(
-                NicknameCheckResponse.unavailable(nickname, e.getMessage())
-        );
+        try {
+            memberService.checkNicknameAvailability(nickname);
+            return ResponseEntity.ok(NicknameCheckResponse.available(nickname));
+        } catch (NicknameException e) {
+            return ResponseEntity.ok(NicknameCheckResponse.unavailable(nickname, e.getErrorCode()));
+        }
     }
 
     @PostMapping("/me/complete-registration")

--- a/src/main/java/econovation/moongtaengi/member/api/dto/NicknameCheckResponse.java
+++ b/src/main/java/econovation/moongtaengi/member/api/dto/NicknameCheckResponse.java
@@ -1,17 +1,21 @@
 package econovation.moongtaengi.member.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import econovation.moongtaengi.global.exception.ErrorCode;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record NicknameCheckResponse(
         String nickname,
         boolean isAvailable,
+        String code,
         String message
-        //에러코드 추가 예정
 ) {
     public static NicknameCheckResponse available(String nickname) {
-        return new NicknameCheckResponse(nickname, true, "사용 가능한 닉네임입니다.");
+        return new NicknameCheckResponse(nickname, true, null,"사용 가능한 닉네임입니다.");
     }
 
 
-    public static NicknameCheckResponse unavailable(String nickname, String reason) {
-        return new NicknameCheckResponse(nickname, false, reason);
+    public static NicknameCheckResponse unavailable(String nickname, ErrorCode errorCode) {
+        return new NicknameCheckResponse(nickname, false, errorCode.getCode(), errorCode.getMessage());
     }
 }

--- a/src/main/java/econovation/moongtaengi/member/application/MemberNotFoundException.java
+++ b/src/main/java/econovation/moongtaengi/member/application/MemberNotFoundException.java
@@ -1,11 +1,11 @@
-package econovation.moongtaengi.member.exception;
+package econovation.moongtaengi.member.application;
 
 import econovation.moongtaengi.global.exception.BusinessException;
-import econovation.moongtaengi.global.exception.ErrorCode;
+import econovation.moongtaengi.member.domain.MemberErrorCode;
 
 public class MemberNotFoundException extends BusinessException {
 
     public MemberNotFoundException() {
-        super(ErrorCode.MEMBER_NOT_FOUND);
+        super(MemberErrorCode.MEMBER_NOT_FOUND);
     }
 }

--- a/src/main/java/econovation/moongtaengi/member/application/MemberService.java
+++ b/src/main/java/econovation/moongtaengi/member/application/MemberService.java
@@ -4,7 +4,6 @@ import econovation.moongtaengi.member.domain.Member;
 import econovation.moongtaengi.member.domain.MemberRepository;
 import econovation.moongtaengi.member.domain.Nickname;
 import econovation.moongtaengi.member.domain.NicknameFactory;
-import econovation.moongtaengi.member.exception.MemberNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/econovation/moongtaengi/member/domain/AlreadyRegisteredException.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/AlreadyRegisteredException.java
@@ -1,11 +1,10 @@
-package econovation.moongtaengi.member.exception;
+package econovation.moongtaengi.member.domain;
 
 import econovation.moongtaengi.global.exception.BusinessException;
-import econovation.moongtaengi.global.exception.ErrorCode;
 
 public class AlreadyRegisteredException extends BusinessException {
 
     public AlreadyRegisteredException() {
-        super(ErrorCode.ALREADY_REGISTERED);
+        super(MemberErrorCode.ALREADY_REGISTERED);
     }
 }

--- a/src/main/java/econovation/moongtaengi/member/domain/Member.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/Member.java
@@ -1,7 +1,6 @@
 package econovation.moongtaengi.member.domain;
 
 import econovation.moongtaengi.global.entity.BaseEntity;
-import econovation.moongtaengi.member.exception.AlreadyRegisteredException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;

--- a/src/main/java/econovation/moongtaengi/member/domain/MemberErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/MemberErrorCode.java
@@ -8,8 +8,16 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
+    //멤버
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_001", "존재하지 않는 회원입니다."),
-    ALREADY_REGISTERED(HttpStatus.CONFLICT, "MEMBER_002", "이미 회원가입이 완료된 회원입니다.");
+    ALREADY_REGISTERED(HttpStatus.CONFLICT, "MEMBER_002", "이미 회원가입이 완료된 회원입니다."),
+
+    //닉네임
+    NICKNAME_NOT_BLANK(HttpStatus.BAD_REQUEST, "NICK_001", "닉네임은 비어있을 수 없습니다."),
+    NICKNAME_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "NICK_002", "닉네임은 %d자 이상 %d자 이하여야 합니다."),
+    NICKNAME_INVALID_PATTERN(HttpStatus.BAD_REQUEST, "NICK_003", "닉네임은 한글과 숫자 조합으로만 가능합니다."),
+    NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "NICK_004", "이미 사용 중인 닉네임입니다."),
+    NICKNAME_BAD_WORD(HttpStatus.BAD_REQUEST, "NICK_005", "비속어가 포함되어 있습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/econovation/moongtaengi/member/domain/MemberErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/MemberErrorCode.java
@@ -1,0 +1,17 @@
+package econovation.moongtaengi.member.domain;
+
+import econovation.moongtaengi.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_001", "존재하지 않는 회원입니다."),
+    ALREADY_REGISTERED(HttpStatus.CONFLICT, "MEMBER_002", "이미 회원가입이 완료된 회원입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/econovation/moongtaengi/member/domain/Nickname.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/Nickname.java
@@ -28,15 +28,15 @@ public class Nickname {
 
     private void validate(String value) {
         if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException("닉네임은 비어있을 수 없습니다.");
+            throw new NicknameException(MemberErrorCode.NICKNAME_NOT_BLANK);
         }
 
         if (value.length() < MIN_LENGTH || value.length() > MAX_LENGTH) {
-            throw new IllegalArgumentException("닉네임은 " + MIN_LENGTH + "자 이상 " + MAX_LENGTH + "자 이하여야 합니다.");
+            throw new NicknameException(MemberErrorCode.NICKNAME_LENGTH_INVALID, MIN_LENGTH, MAX_LENGTH);
         }
 
         if (!PATTERN.matcher(value).matches()) {
-            throw new IllegalArgumentException("닉네임은 한글과 숫자 조합으로만 가능합니다.");
+            throw new NicknameException(MemberErrorCode.NICKNAME_INVALID_PATTERN);
         }
     }
 }

--- a/src/main/java/econovation/moongtaengi/member/domain/NicknameException.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/NicknameException.java
@@ -1,0 +1,13 @@
+package econovation.moongtaengi.member.domain;
+
+import econovation.moongtaengi.global.exception.BusinessException;
+
+public class NicknameException extends BusinessException {
+    public NicknameException(MemberErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public NicknameException(MemberErrorCode errorCode, Object ...args) {
+        super(errorCode, args);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/member/domain/NicknameFactory.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/NicknameFactory.java
@@ -21,13 +21,13 @@ public class NicknameFactory {
 
     private void validateBadWord(Nickname nickname) {
         if (badWordValidator.containsBadWord(nickname.getValue())) {
-            throw new IllegalArgumentException("비속어가 포함되어 있습니다.");
+            throw new NicknameException(MemberErrorCode.NICKNAME_BAD_WORD);
         }
     }
 
     private void validateDuplication(Nickname nickname) {
         if (memberRepository.existsByNicknameValue(nickname.getValue())) {
-            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+            throw new NicknameException(MemberErrorCode.NICKNAME_DUPLICATED);
         }
     }
 }

--- a/src/main/java/econovation/moongtaengi/member/infrastructure/oauth/exception/KakaoAuthException.java
+++ b/src/main/java/econovation/moongtaengi/member/infrastructure/oauth/exception/KakaoAuthException.java
@@ -6,10 +6,10 @@ import econovation.moongtaengi.global.exception.ErrorCode;
 public class KakaoAuthException extends BusinessException {
 
     public KakaoAuthException() {
-        super(ErrorCode.KAKAO_AUTH_FAILED);
+        super(KakaoErrorCode.KAKAO_AUTH_FAILED);
     }
 
     public KakaoAuthException(Throwable cause) {
-        super(ErrorCode.KAKAO_AUTH_FAILED, cause);
+        super(KakaoErrorCode.KAKAO_AUTH_FAILED, cause);
     }
 }

--- a/src/main/java/econovation/moongtaengi/member/infrastructure/oauth/exception/KakaoErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/member/infrastructure/oauth/exception/KakaoErrorCode.java
@@ -1,0 +1,17 @@
+package econovation.moongtaengi.member.infrastructure.oauth.exception;
+
+import econovation.moongtaengi.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum KakaoErrorCode implements ErrorCode {
+    KAKAO_AUTH_FAILED(HttpStatus.UNAUTHORIZED, "KAKAO_001", "카카오 인증에 실패했습니다."),
+    KAKAO_SERVER_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "KAKAO_002", "카카오 서버에 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/econovation/moongtaengi/member/infrastructure/oauth/exception/KakaoServerException.java
+++ b/src/main/java/econovation/moongtaengi/member/infrastructure/oauth/exception/KakaoServerException.java
@@ -6,10 +6,10 @@ import econovation.moongtaengi.global.exception.ErrorCode;
 public class KakaoServerException extends BusinessException {
 
     public KakaoServerException() {
-            super(ErrorCode.KAKAO_SERVER_ERROR);
+            super(KakaoErrorCode.KAKAO_SERVER_ERROR);
         }
 
     public KakaoServerException(Throwable cause) {
-            super(ErrorCode.KAKAO_SERVER_ERROR, cause);
+            super(KakaoErrorCode.KAKAO_SERVER_ERROR, cause);
         }
     }

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyCreateLimitException.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyCreateLimitException.java
@@ -1,0 +1,10 @@
+package econovation.moongtaengi.study.domain;
+
+import econovation.moongtaengi.global.exception.BusinessException;
+
+public class StudyCreateLimitException extends BusinessException {
+
+    public StudyCreateLimitException(int limit) {
+        super(StudyErrorCode.STUDY_CREATION_LIMIT_EXCEEDED, limit);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyErrorCode.java
@@ -1,0 +1,34 @@
+package econovation.moongtaengi.study.domain;
+
+import econovation.moongtaengi.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum StudyErrorCode implements ErrorCode {
+    //스터디
+    STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY_001", "존재하지 않는 스터디입니다."),
+
+    // 스터디 생성 제한
+    STUDY_CREATION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "STUDY_002", "스터디는 최대 %d개까지만 생성 가능합니다."),
+
+    // 스터디 이름
+    NAME_NOT_BLANK(HttpStatus.BAD_REQUEST, "STUDY_003", "스터디 이름은 비어있을 수 없습니다."),
+    NAME_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "STUDY_004", "스터디 이름은 %d자 이상 %d자 이하여야 합니다."),
+    NAME_PATTERN_INVALID(HttpStatus.BAD_REQUEST, "STUDY_005", "스터디 이름의 형식이 올바르지 않습니다."),
+
+    // 스터디 기간
+    PERIOD_NOT_NULL(HttpStatus.BAD_REQUEST, "STUDY_006", "시작일과 종료일은 필수입니다."),
+    PERIOD_DATE_INVALID(HttpStatus.BAD_REQUEST, "STUDY_007", "종료일이 시작일보다 앞에 있을 수 없습니다."),
+    PERIOD_DAYS_INVALID(HttpStatus.BAD_REQUEST, "STUDY_008", "기간은 %d일 이상 %d일 이하여야 합니다."),
+
+    // 스터디 주제
+    TOPIC_NOT_BLANK(HttpStatus.BAD_REQUEST, "STUDY_009", "스터디 주제는 필수입니다."),
+    TOPIC_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "STUDY_010", "스터디 주제는 최대 %d자까지만 가능합니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyException.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyException.java
@@ -1,0 +1,14 @@
+package econovation.moongtaengi.study.domain;
+
+import econovation.moongtaengi.global.exception.BusinessException;
+import econovation.moongtaengi.global.exception.ErrorCode;
+
+public class StudyException extends BusinessException {
+    public StudyException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public StudyException(ErrorCode errorCode, Object... args) {
+        super(errorCode, args);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyFactory.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyFactory.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Component;
 public class StudyFactory {
     private final StudyRepository studyRepository;
 
+    private static final int MAX_HOSTED_COUNT = 5;
+
     public Study createStudy(Long memberId,
             String rawName,
             LocalDate startDate,
@@ -16,8 +18,8 @@ public class StudyFactory {
             String topic) {
         int hostedCount = studyRepository.countByMemberIdAndRole(memberId, StudyRole.HOST);
 
-        if (hostedCount >= 5) {
-            throw new IllegalArgumentException("스터디는 최대 5개까지만 생성 가능합니다.");
+        if (hostedCount >= MAX_HOSTED_COUNT) {
+            throw new StudyCreateLimitException(MAX_HOSTED_COUNT);
         }
 
         StudyName studyName = new StudyName(rawName);

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyName.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyName.java
@@ -28,15 +28,15 @@ public class StudyName {
 
     private void validate(String value) {
         if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException("스터디 이름은 비어있을 수 없습니다.");
+            throw new StudyException(StudyErrorCode.NAME_NOT_BLANK);
         }
 
         if (value.length() < MIN_LENGTH || value.length() > MAX_LENGTH) {
-            throw new IllegalArgumentException("스터디 이름은 " + MIN_LENGTH + "자 이상 " + MAX_LENGTH + "자 이하여야 합니다.");
+            throw new StudyException(StudyErrorCode.NAME_LENGTH_INVALID, MIN_LENGTH, MAX_LENGTH);
         }
 
         if (!PATTERN.matcher(value).matches()) {
-            throw new IllegalArgumentException("스터디 이름의 형식이 올바르지 않습니다.");
+            throw new StudyException(StudyErrorCode.NAME_PATTERN_INVALID);
         }
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyPeriod.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyPeriod.java
@@ -35,17 +35,17 @@ public class StudyPeriod {
 
     private void validate(LocalDate startDate, LocalDate endDate) {
         if (startDate == null || endDate == null) {
-            throw new IllegalArgumentException("시작일과 종료일은 필수입니다.");
+            throw new StudyException(StudyErrorCode.PERIOD_NOT_NULL);
         }
 
         if (endDate.isBefore(startDate)) {
-            throw new IllegalArgumentException("종료일이 시작일보다 앞에 있을 수 없습니다.");
+            throw new StudyException(StudyErrorCode.PERIOD_DATE_INVALID);
         }
 
         long days = ChronoUnit.DAYS.between(startDate, endDate) + 1;
 
         if (days < MIN_TOTAL_DAYS || days > MAX_TOTAL_DAYS) {
-            throw new IllegalArgumentException("기간은 " + MIN_TOTAL_DAYS + " 이상 " + MAX_TOTAL_DAYS + " 이하여야 합니다.");
+            throw new StudyException(StudyErrorCode.PERIOD_DAYS_INVALID, MIN_TOTAL_DAYS, MAX_TOTAL_DAYS);
         }
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyTopic.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyTopic.java
@@ -25,11 +25,11 @@ public class StudyTopic {
 
     private void validate(String value) {
         if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException("스터디 주제는 필수입니다.");
+            throw new StudyException(StudyErrorCode.TOPIC_NOT_BLANK);
         }
 
         if (value.length() > MAX_LENGTH) {
-            throw new IllegalArgumentException("스터디 주제는 최대 " + MAX_LENGTH + "자까지만 가능합니다.");
+            throw new StudyException(StudyErrorCode.TOPIC_LENGTH_INVALID, MAX_LENGTH);
         }
     }
 }

--- a/src/test/java/econovation/moongtaengi/member/api/MemberControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/member/api/MemberControllerTest.java
@@ -1,6 +1,7 @@
 package econovation.moongtaengi.member.api;
 
 import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -9,6 +10,8 @@ import econovation.moongtaengi.global.security.JwtAuthenticationEntryPoint;
 import econovation.moongtaengi.global.security.JwtTokenProvider;
 import econovation.moongtaengi.global.security.config.SecurityConfig;
 import econovation.moongtaengi.member.application.MemberService;
+import econovation.moongtaengi.member.domain.MemberErrorCode;
+import econovation.moongtaengi.member.domain.NicknameException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,31 +39,51 @@ public class MemberControllerTest {
     private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Test
-    @DisplayName("사용 가능한 닉네임은 isAvaiable = true를 반환한다.")
+    @DisplayName("사용 가능한 닉네임은 200 OK와 함께 isAvaiable = true를 반환한다.")
     void 닉네임_체크_성공() throws Exception {
         String validName = "뭉탱이1";
 
         mvc.perform(get("/api/members/check-nickname")
                     .param("nickname", validName)
                     .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.nickname").value(validName))
                 .andExpect(jsonPath("$.isAvailable").value(true));
     }
 
     @Test
-    @DisplayName("중복되거나 비속어인 닉네임은 isAvailable=false와 메시지를 반환한다")
-    void 닉네임_체크_실패() throws Exception {
+    @DisplayName("비속어인 닉네임은 200 OK와 함께 isAvailable=false와 에러코드(NICK_005)를 반환한다.")
+    void 닉네임_체크_성공_비속어_포함() throws Exception {
         String invalidNickname = "개똥이1";
 
-        doThrow(new IllegalArgumentException("비속어가 포함되어 있습니다."))
+        doThrow(new NicknameException(MemberErrorCode.NICKNAME_BAD_WORD))
                 .when(memberService).checkNicknameAvailability(invalidNickname);
 
         mvc.perform(get("/api/members/check-nickname")
                         .param("nickname", invalidNickname)
                         .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("NICK_005"))
+                .andExpect(jsonPath("$.message").value("비속어가 포함되어 있습니다."));
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 닉네임은 200 OK와 함께 에러 코드(NICK_002)를 반환한다")
+    void 닉네임_체크_성공_중복() throws Exception {
+        String duplicateName = "아임중복";
+
+        doThrow(new NicknameException(MemberErrorCode.NICKNAME_DUPLICATED))
+                .when(memberService).checkNicknameAvailability(duplicateName);
+
+        mvc.perform(get("/api/members/check-nickname")
+                        .param("nickname", duplicateName)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isAvailable").value(false))
-                .andExpect(jsonPath("$.message").value("비속어가 포함되어 있습니다."));
+                .andExpect(jsonPath("$.code").value("NICK_004"))
+                .andExpect(jsonPath("$.message").value("이미 사용 중인 닉네임입니다."));
     }
 }

--- a/src/test/java/econovation/moongtaengi/member/domain/NicknameFactoryTest.java
+++ b/src/test/java/econovation/moongtaengi/member/domain/NicknameFactoryTest.java
@@ -45,8 +45,9 @@ public class NicknameFactoryTest {
         given(badWordValidator.containsBadWord(badName)).willReturn(true);
 
         assertThatThrownBy(() -> nicknameFactory.createNickname(badName))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("비속어가 포함되어 있습니다.");
+                .isInstanceOf(NicknameException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberErrorCode.NICKNAME_BAD_WORD);
     }
 
     @Test
@@ -58,7 +59,8 @@ public class NicknameFactoryTest {
         given(memberRepository.existsByNicknameValue(duplicateName)).willReturn(true);
 
         assertThatThrownBy(() -> nicknameFactory.createNickname(duplicateName))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 사용 중인 닉네임입니다.");
+                .isInstanceOf(NicknameException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberErrorCode.NICKNAME_DUPLICATED);
     }
 }

--- a/src/test/java/econovation/moongtaengi/member/domain/NicknameTest.java
+++ b/src/test/java/econovation/moongtaengi/member/domain/NicknameTest.java
@@ -24,24 +24,28 @@ public class NicknameTest {
     @DisplayName("닉네임은 null이거나 비어있을 수 없다")
     void 닉네임_null_빈값_체크() {
         assertThatThrownBy(() -> new Nickname(null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(ERR_MSG_NULL);
+                .isInstanceOf(NicknameException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberErrorCode.NICKNAME_NOT_BLANK);
 
         assertThatThrownBy(() -> new Nickname(""))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(ERR_MSG_NULL);
+                .isInstanceOf(NicknameException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberErrorCode.NICKNAME_NOT_BLANK);
     }
 
     @Test
     @DisplayName("닉네임 길이는 2자 이상 7자 이하여야 한다.")
     void 닉네임_길이_체크() {
         assertThatThrownBy(() -> new Nickname("뭉"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining(ERR_MSG_LENGTH);
+                .isInstanceOf(NicknameException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberErrorCode.NICKNAME_LENGTH_INVALID);
 
         assertThatThrownBy(() -> new Nickname("뭉탱이뭉탱이뭉탱이"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining(ERR_MSG_LENGTH);
+                .isInstanceOf(NicknameException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberErrorCode.NICKNAME_LENGTH_INVALID);
     }
 
     @ParameterizedTest
@@ -49,9 +53,8 @@ public class NicknameTest {
     @DisplayName("닉네임이 한글 숫자 조합이 아닐 경우 예외가 발생한다.")
     void 닉네임_형식_체크(String invalidNickname) {
         assertThatThrownBy(() -> new Nickname(invalidNickname))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(ERR_MSG_PATTERN);
+                .isInstanceOf(NicknameException.class)
+                .extracting("errorCode")
+                .isEqualTo(MemberErrorCode.NICKNAME_INVALID_PATTERN);
     }
-
-
 }

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyFactoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyFactoryTest.java
@@ -56,7 +56,8 @@ public class StudyFactoryTest {
 
         // when & then
         assertThatThrownBy(() -> studyFactory.createStudy(hostId, "새 스터디", start, end, topic))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("5개까지만");
+                .isInstanceOf(StudyCreateLimitException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.STUDY_CREATION_LIMIT_EXCEEDED);
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyNameTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyNameTest.java
@@ -3,6 +3,7 @@ package econovation.moongtaengi.study.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import econovation.moongtaengi.member.domain.NicknameException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -44,12 +45,14 @@ public class StudyNameTest {
 
         //when&then
         assertThatThrownBy(() -> new StudyName(nullValue))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("스터디 이름은 비어있을 수 없습니다.");
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.NAME_NOT_BLANK);
 
         assertThatThrownBy(() -> new StudyName(blankValue))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("스터디 이름은 비어있을 수 없습니다.");
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.NAME_NOT_BLANK);
     }
 
     @Test
@@ -61,12 +64,14 @@ public class StudyNameTest {
 
         //when&then
         assertThatThrownBy(() -> new StudyName(shortName))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("2자 이상");
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.NAME_LENGTH_INVALID);
 
         assertThatThrownBy(() -> new StudyName(longName))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("10자 이하");
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.NAME_LENGTH_INVALID);
     }
 
     @ParameterizedTest
@@ -75,7 +80,8 @@ public class StudyNameTest {
     void 스터디이름_형식_체크(String invalidValue) {
         //when&then
         assertThatThrownBy(() -> new StudyName(invalidValue))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("스터디 이름의 형식이 올바르지 않습니다.");
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.NAME_PATTERN_INVALID);
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyPeriodTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyPeriodTest.java
@@ -44,12 +44,14 @@ public class StudyPeriodTest {
 
         //when&then
         assertThatThrownBy(() -> new StudyPeriod(nullDate, now))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("시작일과 종료일은 필수입니다.");
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.PERIOD_NOT_NULL);
 
         assertThatThrownBy(() -> new StudyPeriod(now, nullDate))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("시작일과 종료일은 필수입니다.");
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.PERIOD_NOT_NULL);
     }
 
     @Test
@@ -61,8 +63,9 @@ public class StudyPeriodTest {
 
         // when & then
         assertThatThrownBy(() -> new StudyPeriod(start, end))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("종료일이 시작일보다 앞에 있을 수 없습니다.");
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.PERIOD_DATE_INVALID);
     }
 
     @Test
@@ -74,8 +77,9 @@ public class StudyPeriodTest {
 
         // when & then
         assertThatThrownBy(() -> new StudyPeriod(start, end))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("730 이하");
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.PERIOD_DAYS_INVALID);
     }
 
 }

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyTopicTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyTopicTest.java
@@ -36,12 +36,14 @@ public class StudyTopicTest {
 
         //when&then
         assertThatThrownBy(() -> new StudyTopic(nullValue))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("필수");
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.TOPIC_NOT_BLANK);
 
         assertThatThrownBy(() -> new StudyTopic(blankValue))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("필수");
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.TOPIC_NOT_BLANK);
     }
 
     @Test
@@ -49,7 +51,8 @@ public class StudyTopicTest {
     void 주제_길이_체크() {
         String longTopic = "1234567890123456789011238746178236478126348716238471623874612387461412341234231123412341234123412341234321";
         assertThatThrownBy(() -> new StudyTopic(longTopic))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("50자");
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.TOPIC_LENGTH_INVALID);
     }
 }


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->
close #16 
close #11
### 🧑‍💻 구현한 내용
1. Global Layer 
- 에러 코드 구조 개선:
   - `ErrorCode` 인터페이스를 도입하여, 각 도메인 패키지 내부에서 독립적인 Enum(`MemberErrorCode`, `StudyErrorCode` 등)을 관리할 수 있도록 구조를 분리

2. Member Domain (Nickname)
- 커스텀 예외 적용:
   - `NicknameException` 구현 및 `Nickname`, `NicknameFactory` 내부의 표준 예외를 에러코드를 적용하여 교체
- API 응답 전략 변경 (`GET /check-nickname`):
   - `@ExceptionHandler`가 아닌 try-catch 로 변경
- DTO:
   - `NicknameCheckResponse`에 `code` 필드를 추가하고, `ErrorCode` 를 받는 정적 팩토리 메서드를 구현

3. Study Domain
- 커스텀 예외 적용:
   - `StudyFactory` 및 `VO`(`Name`, `Period`, `Topic`) 내부의 검증 로직에 에러코드를 적용하여 표준 예외를 커스텀 예외로 교체
   - 비즈니스 예외 세분화:
   - 일반적인 검증 오류는 `StudyException`으로 통합하고, '생성 개수 5개 제한'과 같은 중요한 비즈니스 규칙 위반은 `StudyLimitExceededException`으로 별도 분리

4. Test 
- Unit Test: `NicknameTest`, `NicknameFactoryTest`, `StudyFactoryTest`, `StudyVO` 테스트 등에서 변경된 예외 클래스와 에러 코드가 정확히 반환되는지 검증 로직을 업데이트
- Controller Test: `MemberControllerTest`의 비속어/중복(Unavailable) 케이스에서 `200 OK`와 올바른 `Error Code`가 반환되는지 검증
### 🧪 테스트 결과
따로 API는 없어서 포스트맨 테스트는 못했지만 단위 테스트 모두 통과하였습니다!
### 👿 트러블 슈팅

### 💬 코멘트
에러 코드를 인터페이스화하여 각 도메인 영역 단위로 분리하여 관리할 수 있도록 변경했습니다. 
에러 코드 분리하면서 느낀 점인데, Auth와 Member는 성격이 달라서 향후 별도의 컨텍스트로 분리하는 방향도 고려해보면 좋을 것 같습니다!


