### PR TITLE
feat: 스터디 초대 코드 생성 및 중복 방지 로직 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/domain/InviteCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/InviteCode.java
@@ -1,0 +1,43 @@
+package econovation.moongtaengi.study.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InviteCode {
+    private static final int LENGTH = 8;
+
+    @Column(name = "invite_code", nullable = false, unique = true)
+    private String value;
+
+    public InviteCode(String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    public static InviteCode generate() {
+        String randomCode = UUID.randomUUID().toString()
+                .replaceAll("-", "")
+                .substring(0, LENGTH);
+
+        return new InviteCode(randomCode);
+    }
+
+    private void validate(String value) {
+        if (value == null) {
+            throw new IllegalStateException("초대코드는 필수입니다.");
+        }
+
+        if (value.length() != LENGTH) {
+            throw new IllegalStateException("초대코드는 " + LENGTH + "글자입니다.");
+        }
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/Study.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/Study.java
@@ -26,13 +26,17 @@ public class Study extends BaseEntity {
     @Embedded
     StudyTopic topic;
 
+    @Embedded
+    InviteCode inviteCode;
+
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StudyMember> members = new ArrayList<>();
 
-    public Study(StudyName name, StudyPeriod period, StudyTopic topic, Long hostId) {
+    public Study(StudyName name, StudyPeriod period, StudyTopic topic, Long hostId, InviteCode inviteCode) {
         this.name = name;
         this.period = period;
         this.topic = topic;
+        this.inviteCode = inviteCode;
         addMember(hostId, StudyRole.HOST); //스터디를 생성한 사람은 방장
     }
 

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyFactory.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyFactory.java
@@ -26,6 +26,24 @@ public class StudyFactory {
         StudyPeriod studyPeriod = new StudyPeriod(startDate, endDate);
         StudyTopic studyTopic = new StudyTopic(topic);
 
-        return new Study(studyName, studyPeriod, studyTopic, memberId);
+        InviteCode inviteCode = generateUniqueInviteCode();
+
+        return new Study(studyName, studyPeriod, studyTopic, memberId, inviteCode);
+    }
+
+    private InviteCode generateUniqueInviteCode() {
+        InviteCode inviteCode;
+        int retryCount = 0;
+
+        do {
+            inviteCode = InviteCode.generate();
+            retryCount++;
+
+            if (retryCount > 5) {
+                throw new IllegalStateException("초대 코드 생성에 실패했습니다.");
+            }
+        } while (studyRepository.existsByInviteCodeValue(inviteCode.getValue()));
+
+        return inviteCode;
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.repository.query.Param;
 public interface StudyRepository extends JpaRepository<Study, Long> {
     @Query("select count(s) from Study s join s.members m where m.memberId = :memberId and m.role = :role")
     int countByMemberIdAndRole(@Param("memberId") Long memberId, @Param("role") StudyRole role);
+
+    boolean existsByInviteCodeValue(String value);
 }

--- a/src/test/java/econovation/moongtaengi/study/domain/InviteCodeTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/InviteCodeTest.java
@@ -1,0 +1,51 @@
+package econovation.moongtaengi.study.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class InviteCodeTest {
+    private static final int LENGTH = 8;
+
+    @Test
+    @DisplayName("정상적인 초대코드가 발급된다.")
+    void 초대코드_생성_발급_성공() {
+        //when
+        InviteCode inviteCode = InviteCode.generate();
+
+        //then
+        assertThat(inviteCode).isNotNull();
+        assertThat(inviteCode.getValue()).hasSize(LENGTH);
+    }
+
+    @Test
+    @DisplayName("초대 코드는 null일 수 없다")
+    void 초대코드_생성_null_실패() {
+        //given
+        String code = null;
+
+        //when&then
+        assertThatThrownBy(() -> new InviteCode(code))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("초대코드가 길면")
+    void 초대코드_생성_길이_실패() {
+        //given
+        String longCode = "1234567890";
+        String shortCode = "1234";
+
+        //when&then
+        assertThatThrownBy(() -> new InviteCode(longCode))
+                .isInstanceOf(IllegalStateException.class) // 아까 서버 에러로 처리하기로 했죠?
+                .hasMessageContaining(LENGTH + "글자");
+
+
+        assertThatThrownBy(() -> new InviteCode(shortCode))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(LENGTH + "글자");
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyFactoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyFactoryTest.java
@@ -2,6 +2,7 @@ package econovation.moongtaengi.study.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
@@ -32,6 +33,8 @@ public class StudyFactoryTest {
         String topic = "스프링부트 JPA";
         given(studyRepository.countByMemberIdAndRole(eq(hostId), eq(StudyRole.HOST)))
                 .willReturn(4);
+        given(studyRepository.existsByInviteCodeValue(anyString()))
+                .willReturn(false);
 
         // when
         Study study = studyFactory.createStudy(hostId, studyName, start, end, topic);
@@ -59,5 +62,25 @@ public class StudyFactoryTest {
                 .isInstanceOf(StudyCreateLimitException.class)
                 .extracting("errorCode")
                 .isEqualTo(StudyErrorCode.STUDY_CREATION_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("초대 코드 생성 시 중복이 5번 연속 발생하면 예외가 발생한다")
+    void 초대코드_재시도_초과_실패() {
+        // given
+        Long hostId = 1L;
+        String studyName = "스프링 스터디";
+        LocalDate start = LocalDate.now();
+        LocalDate end = start.plusDays(7);
+        String topic = "스프링부트 JPA";
+        given(studyRepository.countByMemberIdAndRole(eq(hostId), eq(StudyRole.HOST)))
+                .willReturn(4);
+        given(studyRepository.existsByInviteCodeValue(anyString()))
+                .willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> studyFactory.createStudy(hostId, studyName, start, end, topic))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("실패했습니다");
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyTest.java
@@ -15,9 +15,10 @@ public class StudyTest {
         StudyPeriod period = new StudyPeriod(LocalDate.now(), LocalDate.now().plusDays(7));
         StudyTopic topic = new StudyTopic("스프링부트 JPA");
         Long hostId = 1L;
+        InviteCode inviteCode = new InviteCode("12345678");
 
         // when
-        Study study = new Study(name, period, topic, hostId);
+        Study study = new Study(name, period, topic, hostId, inviteCode);
 
         // then
         assertThat(study).isNotNull();


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->
close #18 
### 🧑‍💻 구현한 내용
1. Domain Layer(VO)
- InviteCode 구현:
   - UUID 기반의 8자리 랜덤 문자열 생성 로직
   - 생성자 시점에 길이가 8자리가 아닌 경우를 방어하는 검증 로직을 추가

2. Domain Layer 
- Study 엔티티 수정:
   - `InviteCode`를 `@Embedded` 타입으로 추가하고, 생성자에서 필수값으로 주입받도록 변경
- StudyFactory:
   - 스터디 생성 시 초대 코드 중복 검사 및 재시도 메커니즘을 구현
   - `do-while` 루프를 사용하여 유니크한 코드가 생성될 때까지 시도하며, 최대 5회 재시도 후 실패 시 예외(`IllegalStateException`)를 발생시켜 루프를 방지
- StudyRepository:
   - 초대 코드 중복 여부를 확인하기 위한 `existsByInviteCodeValue` 쿼리 메서드를 추가

3. Test 
- InviteCodeTest: 랜덤 생성된 코드가 8자리인지, 유효하지 않은 값 주입 시 예외가 발생하는지 검증
- StudyFactoryTest:
   - 정상 생성 케이스뿐만 아니라, 초대 코드 중복이 발생했을 때 재시도 로직이 정상 동작하는지, 재시도 횟수 초과 시 예외가 발생하는지를 검증
### 🧪 테스트 결과
테스트 코드 모두 통과하였습니다! 
### 👿 트러블 슈팅

### 💬 코멘트
InviteCode 관련 에러는 서버 내부 에러라서 IllegalStateException 으로 처리했습니다. 이전에 형식 등 다 따져가면서 에러코드 만드니까 이건 오히려 관리비용이 더 높을 것 같아서 추후에 형식 에러 코드 하나로 처리하도록 변경해보겠습니다!


