### PR TITLE
feat: 스터디 생성 API 및 응용 서비스 구현 (추가: @LoginMemberId 구현)

### DIFF
--- a/src/main/java/econovation/moongtaengi/global/annotation/LoginMemberId.java
+++ b/src/main/java/econovation/moongtaengi/global/annotation/LoginMemberId.java
@@ -1,0 +1,11 @@
+package econovation.moongtaengi.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginMemberId {
+}

--- a/src/main/java/econovation/moongtaengi/global/config/WebConfig.java
+++ b/src/main/java/econovation/moongtaengi/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package econovation.moongtaengi.global.config;
+
+import econovation.moongtaengi.global.security.LoginMemberIdArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final LoginMemberIdArgumentResolver loginMemberIdArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberIdArgumentResolver);
+    }
+
+}

--- a/src/main/java/econovation/moongtaengi/global/security/LoginMemberIdArgumentResolver.java
+++ b/src/main/java/econovation/moongtaengi/global/security/LoginMemberIdArgumentResolver.java
@@ -1,0 +1,35 @@
+package econovation.moongtaengi.global.security;
+
+import econovation.moongtaengi.global.annotation.LoginMemberId;
+import econovation.moongtaengi.global.security.exception.UnauthorizedException;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginMemberIdArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasAnnotation = parameter.hasParameterAnnotation(LoginMemberId.class);
+        boolean hasLongType = Long.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasAnnotation && hasLongType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (!(authentication instanceof CustomAuthentication customAuth)) {
+            throw new UnauthorizedException();
+        }
+
+        return customAuth.getPrincipal();
+    }
+}

--- a/src/main/java/econovation/moongtaengi/global/security/exception/UnauthorizedException.java
+++ b/src/main/java/econovation/moongtaengi/global/security/exception/UnauthorizedException.java
@@ -1,0 +1,10 @@
+package econovation.moongtaengi.global.security.exception;
+
+import econovation.moongtaengi.global.exception.BusinessException;
+
+public class UnauthorizedException extends BusinessException {
+
+    public UnauthorizedException() {
+        super(AuthErrorCode.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/api/StudyController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/StudyController.java
@@ -1,0 +1,35 @@
+package econovation.moongtaengi.study.api;
+
+import econovation.moongtaengi.global.annotation.LoginMemberId;
+import econovation.moongtaengi.study.api.dto.StudyCreateRequest;
+import econovation.moongtaengi.study.application.CreateStudyService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/studies")
+public class StudyController {
+    private final CreateStudyService createStudyService;
+
+    @PostMapping
+    public ResponseEntity<Void> createStudy(
+            @LoginMemberId Long memberId,
+            @RequestBody @Valid StudyCreateRequest request) {
+        Long studyId = createStudyService.createStudy(
+                memberId,
+                request.name(),
+                request.topic(),
+                request.startDate(),
+                request.endDate()
+        );
+
+        return ResponseEntity.created(URI.create("/api/studies/" + studyId)).build();
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/api/StudyController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/StudyController.java
@@ -6,12 +6,14 @@ import econovation.moongtaengi.study.application.CreateStudyService;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/studies")
@@ -22,6 +24,9 @@ public class StudyController {
     public ResponseEntity<Void> createStudy(
             @LoginMemberId Long memberId,
             @RequestBody @Valid StudyCreateRequest request) {
+        log.info("스터디 생성 API 호출 - memberId: {}, studyName: {}, studyTopic: {}",
+                memberId, request.name(), request.topic());
+
         Long studyId = createStudyService.createStudy(
                 memberId,
                 request.name(),

--- a/src/main/java/econovation/moongtaengi/study/api/dto/StudyCreateRequest.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/StudyCreateRequest.java
@@ -1,0 +1,20 @@
+package econovation.moongtaengi.study.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public record StudyCreateRequest(
+        @NotBlank(message = "스터디 이름은 필수입니다.")
+        String name,
+
+        @NotBlank(message = "주제는 필수입니다.")
+        String topic,
+
+        @NotNull(message = "시작일은 필수입니다.")
+        LocalDate startDate,
+
+        @NotNull(message = "종료일은 필수입니다.")
+        LocalDate endDate
+) {
+}

--- a/src/main/java/econovation/moongtaengi/study/application/CreateStudyService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/CreateStudyService.java
@@ -5,9 +5,11 @@ import econovation.moongtaengi.study.domain.StudyFactory;
 import econovation.moongtaengi.study.domain.StudyRepository;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CreateStudyService {
@@ -29,6 +31,9 @@ public class CreateStudyService {
         );
 
         studyRepository.save(study);
+
+        log.info("스터디 생성 성공 - studyId: {}, memberId: {}, inviteCode: {}",
+                study.getId(), memberId, study.getInviteCode().getValue());
 
         return study.getId();
     }

--- a/src/main/java/econovation/moongtaengi/study/application/CreateStudyService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/CreateStudyService.java
@@ -1,0 +1,35 @@
+package econovation.moongtaengi.study.application;
+
+import econovation.moongtaengi.study.domain.Study;
+import econovation.moongtaengi.study.domain.StudyFactory;
+import econovation.moongtaengi.study.domain.StudyRepository;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CreateStudyService {
+    private final StudyFactory studyFactory;
+    private final StudyRepository studyRepository;
+
+    @Transactional
+    public Long createStudy(Long memberId,
+            String name,
+            String topic,
+            LocalDate startDate,
+            LocalDate endDate) {
+        Study study = studyFactory.createStudy(
+                memberId,
+                name,
+                startDate,
+                endDate,
+                topic
+        );
+
+        studyRepository.save(study);
+
+        return study.getId();
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/InviteCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/InviteCode.java
@@ -1,0 +1,43 @@
+package econovation.moongtaengi.study.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InviteCode {
+    private static final int LENGTH = 8;
+
+    @Column(name = "invite_code", nullable = false, unique = true)
+    private String value;
+
+    public InviteCode(String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    public static InviteCode generate() {
+        String randomCode = UUID.randomUUID().toString()
+                .replaceAll("-", "")
+                .substring(0, LENGTH);
+
+        return new InviteCode(randomCode);
+    }
+
+    private void validate(String value) {
+        if (value == null) {
+            throw new IllegalStateException("초대코드는 필수입니다.");
+        }
+
+        if (value.length() != LENGTH) {
+            throw new IllegalStateException("초대코드는 " + LENGTH + "글자입니다.");
+        }
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/Study.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/Study.java
@@ -26,13 +26,17 @@ public class Study extends BaseEntity {
     @Embedded
     StudyTopic topic;
 
+    @Embedded
+    InviteCode inviteCode;
+
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StudyMember> members = new ArrayList<>();
 
-    public Study(StudyName name, StudyPeriod period, StudyTopic topic, Long hostId) {
+    public Study(StudyName name, StudyPeriod period, StudyTopic topic, Long hostId, InviteCode inviteCode) {
         this.name = name;
         this.period = period;
         this.topic = topic;
+        this.inviteCode = inviteCode;
         addMember(hostId, StudyRole.HOST); //스터디를 생성한 사람은 방장
     }
 

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyFactory.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyFactory.java
@@ -26,6 +26,24 @@ public class StudyFactory {
         StudyPeriod studyPeriod = new StudyPeriod(startDate, endDate);
         StudyTopic studyTopic = new StudyTopic(topic);
 
-        return new Study(studyName, studyPeriod, studyTopic, memberId);
+        InviteCode inviteCode = generateUniqueInviteCode();
+
+        return new Study(studyName, studyPeriod, studyTopic, memberId, inviteCode);
+    }
+
+    private InviteCode generateUniqueInviteCode() {
+        InviteCode inviteCode;
+        int retryCount = 0;
+
+        do {
+            inviteCode = InviteCode.generate();
+            retryCount++;
+
+            if (retryCount > 5) {
+                throw new IllegalStateException("초대 코드 생성에 실패했습니다.");
+            }
+        } while (studyRepository.existsByInviteCodeValue(inviteCode.getValue()));
+
+        return inviteCode;
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.repository.query.Param;
 public interface StudyRepository extends JpaRepository<Study, Long> {
     @Query("select count(s) from Study s join s.members m where m.memberId = :memberId and m.role = :role")
     int countByMemberIdAndRole(@Param("memberId") Long memberId, @Param("role") StudyRole role);
+
+    boolean existsByInviteCodeValue(String value);
 }

--- a/src/test/java/econovation/moongtaengi/study/api/StudyControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/StudyControllerTest.java
@@ -1,0 +1,100 @@
+package econovation.moongtaengi.study.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import econovation.moongtaengi.global.config.WebConfig;
+import econovation.moongtaengi.global.security.CustomAuthentication;
+import econovation.moongtaengi.global.security.LoginMemberIdArgumentResolver;
+import econovation.moongtaengi.study.api.dto.StudyCreateRequest;
+import econovation.moongtaengi.study.application.CreateStudyService;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(StudyController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({WebConfig.class, LoginMemberIdArgumentResolver.class})
+@MockitoBean(types = JpaMetamodelMappingContext.class)
+public class StudyControllerTest {
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private CreateStudyService createStudyService;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.getContext().setAuthentication(new CustomAuthentication(1L));
+    }
+
+    @Test
+    @DisplayName("스터디 생성 요청 시 서비스 호출 후 201 Created와 Location 헤더를 반환한다")
+    void 스터디_생성_성공() throws Exception {
+        // given
+        StudyCreateRequest request = new StudyCreateRequest(
+                "스프링 스터디",
+                "백엔드",
+                LocalDate.of(2025, 12, 1),
+                LocalDate.of(2025, 12, 31)
+        );
+        given(createStudyService.createStudy(eq(1L), any(), any(), any(), any()))
+                .willReturn(100L);
+
+        // when & then
+        mvc.perform(post("/api/studies")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/api/studies/100"));
+
+        verify(createStudyService).createStudy(
+                eq(1L), // memberId
+                eq(request.name()),
+                eq(request.topic()),
+                eq(request.startDate()),
+                eq(request.endDate())
+        );
+    }
+
+    @Test
+    @DisplayName("필수 값이 누락되면 400 Bad Request를 반환한다")
+    void 스터디_생성_실패_유효성검사() throws Exception {
+        // given
+        StudyCreateRequest invalidRequest = new StudyCreateRequest(
+                "",
+                "",
+                null,
+                null
+        );
+
+        // when & then
+        mvc.perform(post("/api/studies")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+                .andDo(print())
+                .andExpect(status().isInternalServerError()); // 아직 MethodArgumentException 처리를 못함..
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/application/CreateStudyTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/CreateStudyTest.java
@@ -1,0 +1,76 @@
+package econovation.moongtaengi.study.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import econovation.moongtaengi.study.api.dto.StudyCreateRequest;
+import econovation.moongtaengi.study.domain.InviteCode;
+import econovation.moongtaengi.study.domain.Study;
+import econovation.moongtaengi.study.domain.StudyFactory;
+import econovation.moongtaengi.study.domain.StudyName;
+import econovation.moongtaengi.study.domain.StudyPeriod;
+import econovation.moongtaengi.study.domain.StudyRepository;
+import econovation.moongtaengi.study.domain.StudyTopic;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class CreateStudyTest {
+    @Mock
+    private StudyFactory studyFactory;
+
+    @Mock
+    private StudyRepository studyRepository;
+
+    @InjectMocks
+    private CreateStudyService createStudyService;
+
+    @Test
+    @DisplayName("스터디 생성 요청이 오면 Factory를 통해 객체를 생성하고 Repository에 저장한다.")
+    void 스터디_생성_성공() {
+        // given
+        Long memberId = 1L;
+        StudyCreateRequest request = new StudyCreateRequest(
+                "스프링부트 스터디",
+                "JPA",
+                LocalDate.now(),
+                LocalDate.now().plusDays(7)
+        );
+        Study expectedStudy = new Study(
+                new StudyName(request.name()),
+                new StudyPeriod(request.startDate(), request.endDate()),
+                new StudyTopic(request.topic()),
+                memberId,
+                InviteCode.generate()
+        );
+        ReflectionTestUtils.setField(expectedStudy, "id", 1L);
+        given(studyFactory.createStudy(any(), any(), any(), any(), any()))
+                .willReturn(expectedStudy);
+
+        //when
+        Long studyId = createStudyService.createStudy(memberId,
+                request.name(),
+                request.topic(),
+                request.startDate(),
+                request.endDate());
+
+        //then
+        verify(studyFactory).createStudy(
+                memberId,
+                request.name(),
+                request.startDate(),
+                request.endDate(),
+                request.topic()
+        );
+        verify(studyRepository).save(expectedStudy);
+        assertThat(studyId).isEqualTo(expectedStudy.getId());
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/InviteCodeTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/InviteCodeTest.java
@@ -1,0 +1,51 @@
+package econovation.moongtaengi.study.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class InviteCodeTest {
+    private static final int LENGTH = 8;
+
+    @Test
+    @DisplayName("정상적인 초대코드가 발급된다.")
+    void 초대코드_생성_발급_성공() {
+        //when
+        InviteCode inviteCode = InviteCode.generate();
+
+        //then
+        assertThat(inviteCode).isNotNull();
+        assertThat(inviteCode.getValue()).hasSize(LENGTH);
+    }
+
+    @Test
+    @DisplayName("초대 코드는 null일 수 없다")
+    void 초대코드_생성_null_실패() {
+        //given
+        String code = null;
+
+        //when&then
+        assertThatThrownBy(() -> new InviteCode(code))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("초대코드가 길면")
+    void 초대코드_생성_길이_실패() {
+        //given
+        String longCode = "1234567890";
+        String shortCode = "1234";
+
+        //when&then
+        assertThatThrownBy(() -> new InviteCode(longCode))
+                .isInstanceOf(IllegalStateException.class) // 아까 서버 에러로 처리하기로 했죠?
+                .hasMessageContaining(LENGTH + "글자");
+
+
+        assertThatThrownBy(() -> new InviteCode(shortCode))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(LENGTH + "글자");
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyFactoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyFactoryTest.java
@@ -2,6 +2,7 @@ package econovation.moongtaengi.study.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
@@ -32,6 +33,8 @@ public class StudyFactoryTest {
         String topic = "스프링부트 JPA";
         given(studyRepository.countByMemberIdAndRole(eq(hostId), eq(StudyRole.HOST)))
                 .willReturn(4);
+        given(studyRepository.existsByInviteCodeValue(anyString()))
+                .willReturn(false);
 
         // when
         Study study = studyFactory.createStudy(hostId, studyName, start, end, topic);
@@ -59,5 +62,25 @@ public class StudyFactoryTest {
                 .isInstanceOf(StudyCreateLimitException.class)
                 .extracting("errorCode")
                 .isEqualTo(StudyErrorCode.STUDY_CREATION_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("초대 코드 생성 시 중복이 5번 연속 발생하면 예외가 발생한다")
+    void 초대코드_재시도_초과_실패() {
+        // given
+        Long hostId = 1L;
+        String studyName = "스프링 스터디";
+        LocalDate start = LocalDate.now();
+        LocalDate end = start.plusDays(7);
+        String topic = "스프링부트 JPA";
+        given(studyRepository.countByMemberIdAndRole(eq(hostId), eq(StudyRole.HOST)))
+                .willReturn(4);
+        given(studyRepository.existsByInviteCodeValue(anyString()))
+                .willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> studyFactory.createStudy(hostId, studyName, start, end, topic))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("실패했습니다");
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyTest.java
@@ -15,9 +15,10 @@ public class StudyTest {
         StudyPeriod period = new StudyPeriod(LocalDate.now(), LocalDate.now().plusDays(7));
         StudyTopic topic = new StudyTopic("스프링부트 JPA");
         Long hostId = 1L;
+        InviteCode inviteCode = new InviteCode("12345678");
 
         // when
-        Study study = new Study(name, period, topic, hostId);
+        Study study = new Study(name, period, topic, hostId, inviteCode);
 
         // then
         assertThat(study).isNotNull();


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->
close #21 
### 🧑‍💻 구현한 내용
1. Application Layer
- CreateStudyService 구현:
   - `StudyFactory`를 호출하여 도메인 객체를 생성하고 `StudyRepository`에 저장하는 흐름을 제어
   - 설계 의도: Web 계층의 DTO(`StudyCreateRequest`)에 의존하지 않도록, 순수 자바 타입(파라미터 풀기)으로 데이터를 전달받아 계층 간 결합도를 낮춤
- Logging: 스터디 생성 완료 시 생성된 `studyId`, `inviteCode` 등 핵심 정보를 INFO 레벨로 로깅

2. Global & Security 
- @LoginMemberId 구현:
   - `HandlerMethodArgumentResolver`를 구현하여, 컨트롤러에서 `SecurityContextHolder`를 반복 호출하지 않고 어노테이션 하나로 `memberId`를 주입받도록 함
   - 인증 객체가 없거나 타입이 올바르지(`CustomAuthentication`) 않은 경우 `UnauthorizedException`을 발생시킴

3. Presentation Layer 
- StudyController:
   - `POST /api/studies` 엔드포인트 구현
   - 요청: `StudyCreateRequest` DTO를 통해 입력값 유효성(`@Valid`)을 1차 검증
   - 응답: 성공 시 `201 Created` 상태 코드와 함께 `Location` 헤더에 리소스 URI를 반환
   - 로깅: 요청 진입 시 사용자 ID와 주요 요청 필드를 로깅

4. Test
- CreateStudyServiceTest:
   - Mockito를 활용하여 `Factory` 호출 및 `Repository` 저장 흐름을 검증
   - `ReflectionTestUtils`를 사용하여 저장 후 ID 반환 로직까지 검증
- StudyControllerTest (`@WebMvcTest`):
   - Security Filter를 비활성화(`addFilters = false`)하여 순수 컨트롤러 로직 테스트에 집중
   - 정상 생성 및 필수값 누락 케이스를 검증
### 🧪 테스트 결과
<img width="340" height="49" alt="image" src="https://github.com/user-attachments/assets/30b8ff1e-6628-490a-baeb-2056ed538e64" />
<br/>
<img width="340" height="121" alt="image" src="https://github.com/user-attachments/assets/b187c928-203d-49bd-971b-2551ad4a9e71" />
<br/>
<img width="238" height="73" alt="image" src="https://github.com/user-attachments/assets/4439a949-94a9-4e4b-bb3f-71c5b54572ec" />

### 👿 트러블 슈팅
StudyControllerTest 때 Spring Security 쪽 에러가 계속해서 발생. -> `@AutoConfigureMockMvc(addFilters = false)`를 통해 컨트롤러 로직에 집중할 수 있도록함
관련 링크: 
https://computerlove.tistory.com/entry/%ED%9A%8C%EC%9B%90%EA%B0%80%EC%9E%85-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%BD%94%EB%93%9C-%EC%9E%91%EC%84%B1-%EC%8B%9C-%EB%B0%9C%EC%83%9D%ED%95%9C-%EB%AC%B8%EC%A0%9C%EC%A0%90
### 💬 코멘트
다 구현하고 갑자기 생각이 들었는데 임시 회원인 경우 스터디 생성을 못하나...? 라는 게 떠올랐습니다. 이걸 Member랑 의존성을 없애면서 어떻게 구현해야할지 한참 시간이 가버려서 이 부분은 시험 끝나고 보완하도록 하겠습니다..ㅠㅠ


