### PR TITLE
feat: 스터디 생성 자격 검증 로직 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/application/CreateStudyService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/CreateStudyService.java
@@ -1,6 +1,7 @@
 package econovation.moongtaengi.study.application;
 
 import econovation.moongtaengi.study.domain.Study;
+import econovation.moongtaengi.study.domain.StudyCreationValidator;
 import econovation.moongtaengi.study.domain.StudyFactory;
 import econovation.moongtaengi.study.domain.StudyRepository;
 import java.time.LocalDate;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CreateStudyService {
     private final StudyFactory studyFactory;
+    private final StudyCreationValidator studyCreationValidator;
     private final StudyRepository studyRepository;
 
     @Transactional
@@ -22,6 +24,7 @@ public class CreateStudyService {
             String topic,
             LocalDate startDate,
             LocalDate endDate) {
+        studyCreationValidator.validate(memberId);
         Study study = studyFactory.createStudy(
                 memberId,
                 name,

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyCreationValidator.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyCreationValidator.java
@@ -1,0 +1,5 @@
+package econovation.moongtaengi.study.domain;
+
+public interface StudyCreationValidator {
+    void validate(Long memberId);
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyErrorCode.java
@@ -29,7 +29,13 @@ public enum StudyErrorCode implements ErrorCode {
     TOPIC_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "STUDY_010", "스터디 주제는 최대 %d자까지만 가능합니다."),
 
     // 스터디 권한
-    UNAUTHORIZED_PROCESS_ACCESS(HttpStatus.FORBIDDEN, "STUDY_011", "프로세스 생성/수정/삭제 권한이 없습니다. 호스트만 가능합니다.");
+    UNAUTHORIZED_PROCESS_ACCESS(HttpStatus.FORBIDDEN, "STUDY_011", "프로세스 생성/수정/삭제 권한이 없습니다. 호스트만 가능합니다."),
+
+    //임시회원 생성 제한
+    STUDY_CREATION_DENIED_TEMP_MEMBER(HttpStatus.FORBIDDEN, "STUDY_012", "임시회원은 스터디를 생성할 수 없습니다."),
+
+    //스터디 멤버
+    CREATOR_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY_013", "스터디 개설자 정보를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/econovation/moongtaengi/study/infra/StudyCreationValidatorImpl.java
+++ b/src/main/java/econovation/moongtaengi/study/infra/StudyCreationValidatorImpl.java
@@ -1,0 +1,28 @@
+package econovation.moongtaengi.study.infra;
+
+import econovation.moongtaengi.member.application.MemberNotFoundException;
+import econovation.moongtaengi.member.domain.Member;
+import econovation.moongtaengi.member.domain.MemberRepository;
+import econovation.moongtaengi.study.domain.StudyCreationValidator;
+import econovation.moongtaengi.study.domain.StudyErrorCode;
+import econovation.moongtaengi.study.domain.StudyException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class StudyCreationValidatorImpl implements StudyCreationValidator {
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public void validate(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new StudyException(StudyErrorCode.CREATOR_NOT_FOUND));
+
+        if (member.isTemporary()) {
+            throw new StudyException(StudyErrorCode.STUDY_CREATION_DENIED_TEMP_MEMBER);
+        }
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/infra/StudyCreationValidatorImpl.java
+++ b/src/main/java/econovation/moongtaengi/study/infra/StudyCreationValidatorImpl.java
@@ -1,6 +1,5 @@
 package econovation.moongtaengi.study.infra;
 
-import econovation.moongtaengi.member.application.MemberNotFoundException;
 import econovation.moongtaengi.member.domain.Member;
 import econovation.moongtaengi.member.domain.MemberRepository;
 import econovation.moongtaengi.study.domain.StudyCreationValidator;

--- a/src/test/java/econovation/moongtaengi/study/application/CreateStudyTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/CreateStudyTest.java
@@ -1,19 +1,26 @@
 package econovation.moongtaengi.study.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import econovation.moongtaengi.study.api.dto.StudyCreateRequest;
 import econovation.moongtaengi.study.domain.InviteCode;
 import econovation.moongtaengi.study.domain.Study;
+import econovation.moongtaengi.study.domain.StudyCreationValidator;
+import econovation.moongtaengi.study.domain.StudyErrorCode;
+import econovation.moongtaengi.study.domain.StudyException;
 import econovation.moongtaengi.study.domain.StudyFactory;
 import econovation.moongtaengi.study.domain.StudyName;
 import econovation.moongtaengi.study.domain.StudyPeriod;
 import econovation.moongtaengi.study.domain.StudyRepository;
 import econovation.moongtaengi.study.domain.StudyTopic;
 import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +32,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 public class CreateStudyTest {
     @Mock
+    private StudyCreationValidator studyCreationValidator;
+
+    @Mock
     private StudyFactory studyFactory;
 
     @Mock
@@ -33,22 +43,29 @@ public class CreateStudyTest {
     @InjectMocks
     private CreateStudyService createStudyService;
 
-    @Test
-    @DisplayName("스터디 생성 요청이 오면 Factory를 통해 객체를 생성하고 Repository에 저장한다.")
-    void 스터디_생성_성공() {
-        // given
-        Long memberId = 1L;
-        StudyCreateRequest request = new StudyCreateRequest(
+    private StudyCreateRequest commonCreateRequest;
+    private Long commonMemberId;
+
+    @BeforeEach
+    void setUp() {
+        commonMemberId = 1L;
+        commonCreateRequest = new StudyCreateRequest(
                 "스프링부트 스터디",
                 "JPA",
                 LocalDate.now(),
                 LocalDate.now().plusDays(7)
         );
+    }
+
+    @Test
+    @DisplayName("스터디 생성 요청이 오면 Factory를 통해 객체를 생성하고 Repository에 저장한다.")
+    void 스터디_생성_성공() {
+        // given
         Study expectedStudy = new Study(
-                new StudyName(request.name()),
-                new StudyPeriod(request.startDate(), request.endDate()),
-                new StudyTopic(request.topic()),
-                memberId,
+                new StudyName(commonCreateRequest.name()),
+                new StudyPeriod(commonCreateRequest.startDate(), commonCreateRequest.endDate()),
+                new StudyTopic(commonCreateRequest.topic()),
+                commonMemberId,
                 InviteCode.generate()
         );
         ReflectionTestUtils.setField(expectedStudy, "id", 1L);
@@ -56,21 +73,44 @@ public class CreateStudyTest {
                 .willReturn(expectedStudy);
 
         //when
-        Long studyId = createStudyService.createStudy(memberId,
-                request.name(),
-                request.topic(),
-                request.startDate(),
-                request.endDate());
+        Long studyId = createStudyService.createStudy(commonMemberId,
+                commonCreateRequest.name(),
+                commonCreateRequest.topic(),
+                commonCreateRequest.startDate(),
+                commonCreateRequest.endDate());
 
         //then
         verify(studyFactory).createStudy(
-                memberId,
-                request.name(),
-                request.startDate(),
-                request.endDate(),
-                request.topic()
+                commonMemberId,
+                commonCreateRequest.name(),
+                commonCreateRequest.startDate(),
+                commonCreateRequest.endDate(),
+                commonCreateRequest.topic()
         );
         verify(studyRepository).save(expectedStudy);
         assertThat(studyId).isEqualTo(expectedStudy.getId());
+    }
+
+    @Test
+    @DisplayName("validator가 임시회원이라는 이유로 예외를 던지면 스터디 생성 로직이 중단된다.")
+    void 스터디_임시회원_실패_예외발생() {
+        //given
+        willThrow(new StudyException(StudyErrorCode.STUDY_CREATION_DENIED_TEMP_MEMBER))
+                .given(studyCreationValidator).validate(commonMemberId);
+
+
+        //when&then
+        assertThatThrownBy(() -> createStudyService.createStudy(
+                commonMemberId,
+                commonCreateRequest.name(),
+                commonCreateRequest.topic(),
+                commonCreateRequest.startDate(),
+                commonCreateRequest.endDate()
+        ))
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.STUDY_CREATION_DENIED_TEMP_MEMBER);
+
+        verify(studyRepository, never()).save(any());
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/infra/StudyCreationValidatorImplTest.java
+++ b/src/test/java/econovation/moongtaengi/study/infra/StudyCreationValidatorImplTest.java
@@ -1,0 +1,74 @@
+package econovation.moongtaengi.study.infra;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import econovation.moongtaengi.member.domain.Member;
+import econovation.moongtaengi.member.domain.MemberRepository;
+import econovation.moongtaengi.study.domain.StudyErrorCode;
+import econovation.moongtaengi.study.domain.StudyException;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class StudyCreationValidatorImplTest {
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private StudyCreationValidatorImpl studyCreationValidator;
+
+    @Test
+    @DisplayName("정회원이 아닌 임시 회원이면 예외가 발생한다.")
+    void 정회원_검증_실패() {
+        //given
+        Long memberId = 1L;
+
+        Member tempMember = mock(Member.class);
+        given(tempMember.isTemporary()).willReturn(true);
+
+        given(memberRepository.findById(memberId))
+                .willReturn(Optional.of(tempMember));
+
+        //when&then
+        assertThatThrownBy(() -> studyCreationValidator.validate(memberId))
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.STUDY_CREATION_DENIED_TEMP_MEMBER);
+    }
+
+    @Test
+    @DisplayName("정회원일 경우 검증을 통과한다.")
+    void 정회원_검증_성공() {
+        //given
+        Long memberId = 1L;
+
+        Member activeMember = mock(Member.class);
+        given(activeMember.isTemporary()).willReturn(false);
+
+        given(memberRepository.findById(memberId))
+                .willReturn(Optional.of(activeMember));
+
+        //when&then
+        assertDoesNotThrow(() -> studyCreationValidator.validate(memberId));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원일 경우 예외가 발생한다.")
+    void 존재하지않는_회원() {
+        //given
+        Long memberId = 1L;
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> studyCreationValidator.validate(memberId))
+                .isInstanceOf(StudyException.class);
+    }
+
+}


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->
close #24 
### 🧑‍💻 구현한 내용
1. Architecture
- `StudyCreationValidator` (Interface): 스터디 생성 시 필요한 검증 로직을 도메인 영역에 인터페이스로 정의
- `StudyCreationValidatorImpl` (Infra): 인프라 계층에 구현체를 두어 `MemberRepository` 등 외부 의존성을 도메인 로직과 격리 (DIP 적용)

2. Domain
- 스터디 개설 자격 검증 로직 구현
  - 개설자 존재 여부 확인 (DB 조회)
  - 임시 회원의 스터디 개설 제한 정책 적용
- 에러 코드 및 예외 처리
  - `CREATOR_NOT_FOUND`: 개설자 정보 부재 시 발생하는 전용 에러 코드 추가
  - `STUDY_CREATION_DENIED_TEMP_MEMBER`: 임시 회원의 접근 차단 에러 코드 정의
  - Infra 구현체에서 Member 도메인의 예외를 직접 사용하는 대신, Study 도메인 예외를 사용하여 결합도를 낮춤

3. Service
- `createStudy` 스터디 생성 로직 수행 전, 주입받은 `StudyCreationValidator`를 통해 자격 확인 절차 선행

4. Test
- `StudyCreationValidatorImplTest`: 존재하지 않는 회원, 임시 회원, 정회원 케이스에 대한 상세 검증 로직 테스트 작성
- `CreateStudyTest`: 서비스 계층에서 Validator가 올바르게 호출되는지 흐름 검증

### 🧪 테스트 결과
- 테스트 코드 모두 통과되는 것을 확인하였습니다!

### 👿 트러블 슈팅
1. 검증 방식에 대한 고민: 토큰 vs DB 조회
- 고민: 성능을 위해 토큰(JWT) 내 `ROLE` 정보를 파싱하여 임시 회원을 거를지 고민함.
- 문제점: JWT는 발급되는 순간 정보가 고정됨. 사용자가 로그인 후 정회원으로 되더라도, 기존 토큰에는 여전히 TEMPORARY로 남아있는 데이터 불일치 문제가 발생할 수 있음.
- 해결: 사용자에게 재로그인을 강제하기보다는, 비용이 들더라도 DB를 직접 조회하여 최신 상태를 검증하는 방식이 사용자 경험과 데이터 정합성 측면에서 더 낫다고 판단하여 채택.

2. MemberNotFoundException 의존성 격리에 대한 고민
- 문제 상황: `Validator`에서 회원이 존재하지 않을 경우, 기존에 사용하는 `MemberNotFoundException`을 발생시키면 Study 도메인이 Member 도메인의 예외 클래스에 강하게 결합되는 문제가 발생함.
- 해결: 회원이 없는 상황을 처리할 때 외부 예외를 빌려 쓰는 대신, Study 도메인 문맥에 맞는 `StudyException(CREATOR_NOT_FOUND)`을 직접 발생시키도록 구현함. 


### 💬 코멘트
진짜 간단한 로직인데 설계를 어떻게 해야할지 생각하니까 오래걸리네용..



