### PR TITLE
feat: 배포 환경 데이터베이스 전환 (H2 -> AWS RDS MySQL) 및 배포 스크립트 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,5 +60,5 @@ jobs:
                           -p 8080:8080 \
                           ${{ secrets.DOCKER_USERNAME }}/moongtaengi-server:latest
             
-            rm.env
+            rm .env
             sudo docker image prune -f

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	implementation("com.google.genai:google-genai:1.28.0")
 	implementation 'com.google.code.gson:gson:2.10.1'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -5,10 +5,10 @@ spring:
 
   #임시적으로 h2 사용
   datasource:
-    url: jdbc:h2:mem:moongtaengidb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    url: jdbc:mysql://${RDS_HOSTNAME}:${RDS_PORT:3306}/${RDS_DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=false
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${RDS_USERNAME}
+    password: ${RDS_PASSWORD}
 
   jpa:
     hibernate:


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
1. 설정 파일 (application-prod.yml)
  - H2 설정을 제거하고 MySQL 연결 설정으로 변경
  - 민감 정보를 환경 변수($RDS_)로 추출
  - 데이터 정합성을 위한 필수 옵션 추가
    - serverTimezone=Asia/Seoul: DB 시간대 한국 설정
    - characterEncoding=UTF-8: 한글 깨짐 방지
  - 초기 개발 편의를 위해 ddl-auto: update 설정 유지

2. 의존성 (build.gradle)
  - mysql-connector-j (MySQL Driver) 라이브러리 추가

3. CI/CD (.github/workflows/deploy.yml)
  - 배포 스크립트 내 오타 수정 (rm.env -> rm .env)
### 🧪 테스트 결과
- [x] 로컬 환경에서 `./gradlew clean build -x test` 정상 수행 확인
- [ ] DB 연결 테스트는 배포 후 EC2 로그를 통해 확인할 예정.
### 👿 트러블 슈팅

### 💬 코멘트
AWS RDS(MySQL 8.0) 인스턴스 생성이랑 Github 환경변수 설정도 완료해뒀습니다! 


