### PR TITLE
feat: 스터디 중복 가입 방지 도메인 로직 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/domain/Study.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/Study.java
@@ -41,6 +41,7 @@ public class Study extends BaseEntity {
     }
 
     public void addMember(Long memberId, StudyRole studyRole) {
+        validateAlreadyJoined(memberId);
         StudyMember studyMember = new StudyMember(this, memberId, studyRole);
         members.add(studyMember);
     }
@@ -57,6 +58,15 @@ public class Study extends BaseEntity {
 
         if (!isHost) {
             throw new StudyException(StudyErrorCode.UNAUTHORIZED_PROCESS_ACCESS);
+        }
+    }
+
+    private void validateAlreadyJoined(Long memberId) {
+        boolean isAlreadyJoined = this.members.stream()
+                .anyMatch(member -> member.getMemberId().equals(memberId));
+
+        if (isAlreadyJoined) {
+            throw new StudyException(StudyErrorCode.ALREADY_JOINED_MEMBER);
         }
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyErrorCode.java
@@ -32,7 +32,7 @@ public enum StudyErrorCode implements ErrorCode {
     UNAUTHORIZED_PROCESS_ACCESS(HttpStatus.FORBIDDEN, "STUDY_011", "프로세스 생성/수정/삭제 권한이 없습니다. 호스트만 가능합니다."),
 
     //스터디 참여 중복
-    ALREADY_JOINED_MEMBER(HttpStatus.CONFLICT, "STUDY_012", "이미 참여 중인 스터디입니다.");
+    ALREADY_JOINED_MEMBER(HttpStatus.CONFLICT, "STUDY_012", "이미 참여 중인 스터디입니다."),
 
     //임시회원 생성 제한
     STUDY_CREATION_DENIED_TEMP_MEMBER(HttpStatus.FORBIDDEN, "STUDY_013", "임시회원은 스터디를 생성할 수 없습니다."),

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyErrorCode.java
@@ -29,7 +29,10 @@ public enum StudyErrorCode implements ErrorCode {
     TOPIC_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "STUDY_010", "스터디 주제는 최대 %d자까지만 가능합니다."),
 
     // 스터디 권한
-    UNAUTHORIZED_PROCESS_ACCESS(HttpStatus.FORBIDDEN, "STUDY_011", "프로세스 생성/수정/삭제 권한이 없습니다. 호스트만 가능합니다.");
+    UNAUTHORIZED_PROCESS_ACCESS(HttpStatus.FORBIDDEN, "STUDY_011", "프로세스 생성/수정/삭제 권한이 없습니다. 호스트만 가능합니다."),
+
+    //스터디 참여 중복
+    ALREADY_JOINED_MEMBER(HttpStatus.CONFLICT, "STUDY_012", "이미 참여 중인 스터디입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyTest.java
@@ -1,6 +1,7 @@
 package econovation.moongtaengi.study.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +26,48 @@ public class StudyTest {
         assertThat(study.getName()).isEqualTo(name);
         assertThat(study.getMembers()).hasSize(1);
         assertThat(study.getMembers().get(0).getMemberId()).isEqualTo(hostId);
+    }
+
+    @Test
+    @DisplayName("새로운 회원은 스터디에 정상적으로 가입할 수 있다.")
+    void 스터디_가입_성공() {
+        //given
+        Long hostId = 1L;
+        Study study = createStudy(hostId);
+        Long newMemberId = 2L;
+
+        //when
+        study.addMember(newMemberId, StudyRole.GUEST);
+
+        //then
+        assertThat(study.getMembers()).hasSize(2);
+        assertThat(study.getMembers())
+                .extracting("memberId")
+                .contains(1L, 2L);
+    }
+
+    @Test
+    @DisplayName("이미 참여 중인 회원이 가입을 시도하면 예외가 발생한다.")
+    void 스터디_가입_중복_실패() {
+        //given
+        Long hostId = 1L;
+        Study study = createStudy(hostId);
+
+        //when&then
+        assertThatThrownBy(() -> study.addMember(hostId, StudyRole.GUEST))
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.ALREADY_JOINED_MEMBER);
+    }
+
+    private Study createStudy(Long hostId) {
+        return new Study(
+                new StudyName("테스트 스터디"),
+                new StudyPeriod(LocalDate.now(), LocalDate.now().plusDays(7)),
+                new StudyTopic("테스트 주제"),
+                hostId,
+                new InviteCode("12345678")
+        );
     }
 }
 


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->
close #23 
### 🧑‍💻 구현한 내용
1. Domain: 스터디 중복 가입 방지 로직 구현 (Study.java)
   - Study 엔티티가 멤버를 추가하기 전, 스스로 중복 가입 여부를 검증하도록 구현.
   - ErrorCode: ALREADY_JOINED_MEMBER (409 Conflict) 추가

2. Tests: 도메인 단위 테스트 작성 (StudyTest.java)
   - 정상 흐름 검증: 새로운 회원이 가입할 때 리스트에 정상적으로 추가되는지 확인.
   - 예외 흐름 검증: 이미 가입된 회원이 다시 가입을 시도할 때, 지정된 예외와 에러코드(ALREADY_JOINED_MEMBER)가 발생하는지 검증.
### 🧪 테스트 결과
- [x] 테스트 코드 모두 통과하는 것을 확인하였습니다! 
### 👿 트러블 슈팅
검증 시 파라미터 타입에 대한 고민 (Entity vs ID)
고민: validateAlreadyJoined 메서드에서 StudyMember 객체를 받을지, memberId를 받을지 고민함.
결정: 객체를 받으면 검증 전에 불필요한 객체 생성이 선행되어야 함. 따라서 memberId만으로 먼저 검증을 수행하는 것이 효울적이라고 판단.
### 💬 코멘트
기존에 이슈도 만들어둔 것도 있고 이번주 뭔가 바빠질 것 같아서 PR 작게 가져가봤습니다! 머지되면 스터디 참여 API 구현하겠습니다 !!


