### PR TITLE
feat: 프로세스 상태 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/api/dto/ProcessResponse.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/ProcessResponse.java
@@ -12,7 +12,8 @@ public record ProcessResponse(
         LocalDate endDate,
         Long durationDays,
         String memo,
-        String assignmentDescription
+        String assignmentDescription,
+        ProcessStatus status
 ) {
     public static ProcessResponse from(StudyProcess process) {
         return new ProcessResponse(
@@ -23,7 +24,21 @@ public record ProcessResponse(
                 process.getEndDate(),
                 process.getDurationDays(),
                 process.getMemo().getValue(),
-                process.getAssignmentDescription()
+                process.getAssignmentDescription(),
+                calculateStatus(process.getStartDate(), process.getEndDate())
         );
     }
+
+    private static ProcessStatus calculateStatus(LocalDate startDate, LocalDate endDate) {
+        LocalDate today = LocalDate.now();
+
+        if (today.isBefore(startDate)) {
+            return ProcessStatus.NOT_STARTED;  // 예정
+        } else if (today.isAfter(endDate)) {
+            return ProcessStatus.COMPLETED;    // 완료
+        } else {
+            return ProcessStatus.IN_PROGRESS;  // 진행 중
+        }
+    }
+
 }

--- a/src/main/java/econovation/moongtaengi/study/api/dto/ProcessStatus.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/ProcessStatus.java
@@ -1,0 +1,15 @@
+package econovation.moongtaengi.study.api.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProcessStatus {
+    NOT_STARTED("예정", "아직 시작하지 않은 프로세스"),
+    IN_PROGRESS("진행중", "현재 진행 중인 프로세스"),
+    COMPLETED("완료", "완료된 프로세스");
+
+    private final String description;
+    private final String detail;
+}


### PR DESCRIPTION
### 📌 PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈

### 🧑‍💻 구현한 내용
- 프로세스 상태를 나타내기 위해 ProcessResponse에 status 필드 및 계산 로직 추가
- status를 나타내기 위한 ProcessStatus Enum클래스 구현
- 오늘 날짜와 해당 프로세스의 startDate, endDate를 비교하며 NOT_STARTED (예정), COMPLETED (완료), IN_PROGRESS (진행)를 각각 응답해줌

### 🧪 테스트 결과
날짜에 따라서 status 정상적으로 반영되는 것 확인함
<img width="1982" height="1424" alt="image" src="https://github.com/user-attachments/assets/18037ec4-12de-41c9-baee-a4582530b6b2" />
<img width="1982" height="1450" alt="image" src="https://github.com/user-attachments/assets/8c783d72-0750-4a25-a642-241462d4f613" />

### 👿 트러블 슈팅

### 💬 코멘트
- 현재 ProcessStatus 클래스가 dto 패키지 아래에 존재하는데 해당 위치에 둬도 괜찮을지 의논이 필요함 (오직 ProcessResponse dto에서만 사용하기 때문에 dto 패키지 아래에 같이 둬도 괜찮을 것 같아서 이렇게 구현함)

