### PR TITLE
feat: 유저가 관리하는 스터디 목록과 유저가 참여중인 스터디 목록 조회 기능 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/api/MyStudyController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/MyStudyController.java
@@ -1,0 +1,30 @@
+package econovation.moongtaengi.study.api;
+
+import econovation.moongtaengi.global.annotation.LoginMemberId;
+import econovation.moongtaengi.study.api.dto.StudySummaryResponse;
+import econovation.moongtaengi.study.application.StudyQueryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/studies/me")
+public class MyStudyController {
+    private final StudyQueryService studyQueryService;
+
+    @GetMapping("/managed")
+    public ResponseEntity<List<StudySummaryResponse>> getManagedStudies(
+            @LoginMemberId Long memberId) {
+        return ResponseEntity.ok(studyQueryService.getManagedStudies(memberId));
+    }
+
+    @GetMapping("/joined")
+    public ResponseEntity<List<StudySummaryResponse>> getJoinedStudies(
+            @LoginMemberId Long memberId) {
+        return ResponseEntity.ok(studyQueryService.getJoinedStudies(memberId));
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/api/MyStudyController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/MyStudyController.java
@@ -5,11 +5,13 @@ import econovation.moongtaengi.study.api.dto.StudySummaryResponse;
 import econovation.moongtaengi.study.application.StudyQueryService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/studies/me")
@@ -19,12 +21,14 @@ public class MyStudyController {
     @GetMapping("/managed")
     public ResponseEntity<List<StudySummaryResponse>> getManagedStudies(
             @LoginMemberId Long memberId) {
+        log.info("내가 운영 중인 스터디 목록 조회 API 호출 - memberId: {}", memberId);
         return ResponseEntity.ok(studyQueryService.getManagedStudies(memberId));
     }
 
     @GetMapping("/joined")
     public ResponseEntity<List<StudySummaryResponse>> getJoinedStudies(
             @LoginMemberId Long memberId) {
+        log.info("내가 참여 중인 스터디 목록 조회 API 호출 - memberId: {}", memberId);
         return ResponseEntity.ok(studyQueryService.getJoinedStudies(memberId));
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/api/dto/StudySummaryResponse.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/StudySummaryResponse.java
@@ -3,8 +3,8 @@ package econovation.moongtaengi.study.api.dto;
 import econovation.moongtaengi.study.domain.Study;
 
 public record StudySummaryResponse(
-        Long id,
-        String name
+        Long studyId,
+        String studyName
 ) {
     public static StudySummaryResponse from(Study study) {
         return new StudySummaryResponse(

--- a/src/main/java/econovation/moongtaengi/study/api/dto/StudySummaryResponse.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/StudySummaryResponse.java
@@ -1,0 +1,15 @@
+package econovation.moongtaengi.study.api.dto;
+
+import econovation.moongtaengi.study.domain.Study;
+
+public record StudySummaryResponse(
+        Long id,
+        String name
+) {
+    public static StudySummaryResponse from(Study study) {
+        return new StudySummaryResponse(
+                study.getId(),
+                study.getName().getValue()
+        );
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/application/StudyQueryService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/StudyQueryService.java
@@ -1,0 +1,32 @@
+package econovation.moongtaengi.study.application;
+
+import econovation.moongtaengi.study.api.dto.StudySummaryResponse;
+import econovation.moongtaengi.study.domain.StudyMemberRepository;
+import econovation.moongtaengi.study.domain.StudyRole;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyQueryService {
+    private final StudyMemberRepository studyMemberRepository;
+
+    public List<StudySummaryResponse> getManagedStudies(Long memberId) {
+        return studyMemberRepository.findAllByMemberIdAndRole(memberId, StudyRole.HOST)
+                .stream()
+                .map(studyMember -> StudySummaryResponse.from(studyMember.getStudy()))
+                .toList();
+    }
+
+    public List<StudySummaryResponse> getJoinedStudies(Long memberId) {
+        return studyMemberRepository.findAllByMemberIdAndRole(memberId, StudyRole.GUEST)
+                .stream()
+                .map(studyMember -> StudySummaryResponse.from(studyMember.getStudy()))
+                .toList();
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyMemberRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyMemberRepository.java
@@ -1,0 +1,11 @@
+package econovation.moongtaengi.study.domain;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> {
+    @Query("select sm from StudyMember sm join fetch sm.study where sm.memberId = :memberId and sm.role = :role")
+    List<StudyMember> findAllByMemberIdAndRole(@Param("memberId") Long memberId, @Param("role") StudyRole role);
+}

--- a/src/test/java/econovation/moongtaengi/study/api/MyStudyControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/MyStudyControllerTest.java
@@ -57,8 +57,8 @@ public class MyStudyControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray())
-                .andExpect(jsonPath("$[0].id").value(100L))
-                .andExpect(jsonPath("$[0].name").value("관리 스터디"));
+                .andExpect(jsonPath("$[0].studyId").value(100L))
+                .andExpect(jsonPath("$[0].studyName").value("관리 스터디"));
 
         verify(studyQueryService).getManagedStudies(1L);
     }
@@ -78,8 +78,8 @@ public class MyStudyControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray())
-                .andExpect(jsonPath("$[0].id").value(100L))
-                .andExpect(jsonPath("$[0].name").value("참여 스터디"));
+                .andExpect(jsonPath("$[0].studyId").value(100L))
+                .andExpect(jsonPath("$[0].studyName").value("참여 스터디"));
         verify(studyQueryService).getJoinedStudies(1L);
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/api/MyStudyControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/MyStudyControllerTest.java
@@ -1,0 +1,85 @@
+package econovation.moongtaengi.study.api;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import econovation.moongtaengi.global.config.WebConfig;
+import econovation.moongtaengi.global.security.CustomAuthentication;
+import econovation.moongtaengi.global.security.LoginMemberIdArgumentResolver;
+import econovation.moongtaengi.study.api.dto.StudySummaryResponse;
+import econovation.moongtaengi.study.application.StudyQueryService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MyStudyController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({WebConfig.class, LoginMemberIdArgumentResolver.class})
+@MockitoBean(types = JpaMetamodelMappingContext.class)
+public class MyStudyControllerTest {
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private StudyQueryService studyQueryService;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.getContext().setAuthentication(new CustomAuthentication(1L));
+    }
+
+    @Test
+    @DisplayName("내가 관리하는 스터디 목록을 조회한다.")
+    void 내가_관리하는_스터디_조회_성공() throws Exception {
+        //given
+        List<StudySummaryResponse> response = List.of(
+                new StudySummaryResponse(100L, "관리 스터디")
+        );
+        given(studyQueryService.getManagedStudies(anyLong()))
+                .willReturn(response);
+
+        //when&then
+        mvc.perform(get("/api/studies/me/managed"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].id").value(100L))
+                .andExpect(jsonPath("$[0].name").value("관리 스터디"));
+
+        verify(studyQueryService).getManagedStudies(1L);
+    }
+
+    @Test
+    @DisplayName("내가 참여 중인 스터디 목록을 조회한다.")
+    void 내가_참여중인_스터디_조회_성공() throws Exception {
+        //given
+        List<StudySummaryResponse> response = List.of(
+                new StudySummaryResponse(100L, "참여 스터디")
+        );
+        given(studyQueryService.getJoinedStudies(anyLong()))
+                .willReturn(response);
+
+        //when&then
+        mvc.perform(get("/api/studies/me/joined"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].id").value(100L))
+                .andExpect(jsonPath("$[0].name").value("참여 스터디"));
+        verify(studyQueryService).getJoinedStudies(1L);
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/application/StudyQueryServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/StudyQueryServiceTest.java
@@ -60,8 +60,8 @@ public class StudyQueryServiceTest {
 
         // then
         assertThat(result).hasSize(1);
-        assertThat(result.getFirst().name()).isEqualTo("테스트 스터디");
-        assertThat(result.getFirst().id()).isEqualTo(studyId);
+        assertThat(result.getFirst().studyName()).isEqualTo("테스트 스터디");
+        assertThat(result.getFirst().studyId()).isEqualTo(studyId);
         verify(studyMemberRepository).findAllByMemberIdAndRole(memberId, StudyRole.HOST);
     }
 
@@ -95,8 +95,8 @@ public class StudyQueryServiceTest {
 
         //then
         assertThat(result).hasSize(1);
-        assertThat(result.getFirst().name()).isEqualTo("참여하는 스터디");
-        assertThat(result.getFirst().id()).isEqualTo(studyId);
+        assertThat(result.getFirst().studyName()).isEqualTo("참여하는 스터디");
+        assertThat(result.getFirst().studyId()).isEqualTo(studyId);
         verify(studyMemberRepository).findAllByMemberIdAndRole(memberId, StudyRole.GUEST);
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/application/StudyQueryServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/StudyQueryServiceTest.java
@@ -1,0 +1,102 @@
+package econovation.moongtaengi.study.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import econovation.moongtaengi.study.api.dto.StudySummaryResponse;
+import econovation.moongtaengi.study.domain.InviteCode;
+import econovation.moongtaengi.study.domain.Study;
+import econovation.moongtaengi.study.domain.StudyMember;
+import econovation.moongtaengi.study.domain.StudyMemberRepository;
+import econovation.moongtaengi.study.domain.StudyName;
+import econovation.moongtaengi.study.domain.StudyPeriod;
+import econovation.moongtaengi.study.domain.StudyRole;
+import econovation.moongtaengi.study.domain.StudyTopic;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class StudyQueryServiceTest {
+    @InjectMocks
+    private StudyQueryService studyQueryService;
+
+    @Mock
+    private StudyMemberRepository studyMemberRepository;
+
+    @Test
+    @DisplayName("내가 관리하는 스터디 목록을 조회한다.")
+    void 나의_관리_스터디_조회_성공() {
+        // given
+        Long memberId = 1L;
+        Long studyId = 100L;
+
+        Study study = new Study(
+                new StudyName("테스트 스터디"),
+                new StudyPeriod(LocalDate.now(), LocalDate.now().plusDays(7)),
+                new StudyTopic("테스트 주제"),
+                memberId,
+                new InviteCode("12345678")
+        );
+        ReflectionTestUtils.setField(study, "id", studyId);
+
+        StudyMember studyMember = new StudyMember(
+                study,
+                memberId,
+                StudyRole.HOST);
+
+        given(studyMemberRepository.findAllByMemberIdAndRole(memberId, StudyRole.HOST))
+                .willReturn(List.of(studyMember));
+
+        // when
+        List<StudySummaryResponse> result = studyQueryService.getManagedStudies(memberId);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().name()).isEqualTo("테스트 스터디");
+        assertThat(result.getFirst().id()).isEqualTo(studyId);
+        verify(studyMemberRepository).findAllByMemberIdAndRole(memberId, StudyRole.HOST);
+    }
+
+    @Test
+    @DisplayName("내가 참여 중인 스터디 목록을 조회한다.")
+    void 나의_참여_스터디_조회_성공() {
+        //given
+        Long memberId = 1L;
+        Long studyId = 100L;
+
+        Study study = new Study(
+                new StudyName("참여하는 스터디"),
+                new StudyPeriod(LocalDate.now(), LocalDate.now().plusDays(7)),
+                new StudyTopic("스터디 주제"),
+                10L,
+                new InviteCode("12345678")
+        );
+        ReflectionTestUtils.setField(study, "id", studyId);
+
+        StudyMember studyMember = new StudyMember(
+                study,
+                memberId,
+                StudyRole.GUEST
+        );
+
+        given(studyMemberRepository.findAllByMemberIdAndRole(memberId, StudyRole.GUEST))
+                .willReturn(List.of(studyMember));
+
+        //when
+        List<StudySummaryResponse> result = studyQueryService.getJoinedStudies(memberId);
+
+        //then
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().name()).isEqualTo("참여하는 스터디");
+        assertThat(result.getFirst().id()).isEqualTo(studyId);
+        verify(studyMemberRepository).findAllByMemberIdAndRole(memberId, StudyRole.GUEST);
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyMemberRepositoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyMemberRepositoryTest.java
@@ -1,0 +1,51 @@
+package econovation.moongtaengi.study.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.PersistenceUnitUtil;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DataJpaTest
+public class StudyMemberRepositoryTest {
+    @Autowired
+    private StudyMemberRepository studyMemberRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("회원 ID와 역할로 조회 시, 스터디 엔티티까지 fetch join으로 한 번에 가져온다.")
+    void 회원_ID_역할_조회_성공() {
+        //given
+        Long memberId = 1L;
+
+        Study study = new Study(
+                new StudyName("테스트 스터디"),
+                new StudyPeriod(LocalDate.now(), LocalDate.now().plusDays(7)),
+                new StudyTopic("테스트 주제"),
+                memberId,
+                new InviteCode("12345678")
+        );
+        entityManager.persist(study);
+        entityManager.flush();
+        entityManager.clear();
+
+        //when
+        List<StudyMember> result = studyMemberRepository.findAllByMemberIdAndRole(memberId, StudyRole.HOST);
+
+        //then
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getStudy().getName().getValue()).isEqualTo("테스트 스터디");
+
+        PersistenceUnitUtil util = entityManager.getEntityManager().getEntityManagerFactory().getPersistenceUnitUtil();
+        boolean isLoaded = util.isLoaded(result.getFirst().getStudy());
+
+        assertThat(isLoaded).isTrue();
+    }
+}


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->
close #39 
### 🧑‍💻 구현한 내용
1. StudyMemberRepository 구현
  - StudyMemberRepository에 회원 ID와 Role(HOST/GUEST)을 기준으로 스터디 목록을 조회하는 메서드를 추가
  - 스터디 정보 조회 시 발생할 수 있는 N+1 문제를 방지하기 위해 join fetch를 적용하여 Study 엔티티를 한 번에 로딩하도록 최적화
  - DataJpaTest를 통해 Fetch Join 동작 여부와 데이터 조회 정합성을 검증하는 테스트 코드를 작성

2. StudyQuerService 구현
  - StudyQueryService를 생성하여 운영 중인 스터디(getManagedStudies)와 참여 중인 스터디(getJoinedStudies)를 조회하는 로직을 분리하여 구현
  - Mockito를 활용하여 Repository 계층을 Mocking한 단위 테스트를 작성
  - 테스트 과정에서 ReflectionTestUtils를 사용하여 엔티티에 가짜 ID를 주입하는 방식으로 객체 간 의존성을 검증

3. MyStudyController 구현 및 엔드포인트 추가
  - MyStudyController를 생성하고 URL 경로를 /api/studies/me/managed(운영)와 /api/studies/me/joined(참여)로 분리
  - API 호출 시 LoginMemberIdArgumentResolver를 통해 인증된 사용자 ID를 주입받도록 구현
  - API 진입 시 로그 출력
  - WebMvcTest를 기반으로 SecurityContext 연동 및 JSON 응답 형식을 검증하는 컨트롤러 단위 테스트를 작성
### 🧪 테스트 결과
<img width="526" height="497" alt="image" src="https://github.com/user-attachments/assets/797d29cd-05a0-42d4-a019-70fe9da9f56c" />
<img width="526" height="597" alt="image" src="https://github.com/user-attachments/assets/121fead3-6dd2-444f-ba00-5c7a8d92849d" />

### 👿 트러블 슈팅

### 💬 코멘트
막상 빨리 끝날 줄 알았는데 꽤 시간이 걸리네요... 
과제 쪽은 주말 이용해서 끝내보도록 하겠습니다!
그리고 사용자가 스터디로 이동하게 되면 스터디 상세 조회 + 프로세스 목록 조회 + 과제 조회 이렇게 프론트에서 호출하게 되는 건지 한 번 고민해봐야 할 것 같습니다! 


