### PR TITLE
feat: 스터디 상세 조회 기능 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/api/StudyController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/StudyController.java
@@ -2,14 +2,18 @@ package econovation.moongtaengi.study.api;
 
 import econovation.moongtaengi.global.annotation.LoginMemberId;
 import econovation.moongtaengi.study.api.dto.StudyCreateRequest;
+import econovation.moongtaengi.study.api.dto.StudyDetailResponse;
 import econovation.moongtaengi.study.api.dto.StudyJoinRequest;
 import econovation.moongtaengi.study.application.CreateStudyService;
 import econovation.moongtaengi.study.application.JoinStudyService;
+import econovation.moongtaengi.study.application.StudyDetailService;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class StudyController {
     private final CreateStudyService createStudyService;
     private final JoinStudyService joinStudyService;
+    private final StudyDetailService studyDetailService;
 
     @PostMapping
     public ResponseEntity<Void> createStudy(
@@ -51,5 +56,15 @@ public class StudyController {
         joinStudyService.joinStudy(memberId, request.inviteCode());
 
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{studyId}")
+    public ResponseEntity<StudyDetailResponse> getStudyDetail(
+            @PathVariable Long studyId,
+            @LoginMemberId Long memberId
+    ) {
+        log.info("스터디 상 조회 API 호출 - memberId: {}, studyId: {}", memberId, studyId);
+
+        return ResponseEntity.ok(studyDetailService.getStudyDetail(studyId, memberId));
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/api/dto/StudyDetailResponse.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/StudyDetailResponse.java
@@ -1,0 +1,36 @@
+package econovation.moongtaengi.study.api.dto;
+
+import econovation.moongtaengi.study.domain.Study;
+import econovation.moongtaengi.study.domain.StudyMember;
+import econovation.moongtaengi.study.domain.StudyPeriod;
+import econovation.moongtaengi.study.domain.StudyRole;
+import java.time.LocalDate;
+
+public record StudyDetailResponse(
+        Long id,
+        String name,
+        StudyPeriodDto period,
+        String topic,
+        String inviteCode,
+        StudyRole myRole
+) {
+    public record StudyPeriodDto(
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        public static StudyPeriodDto from(StudyPeriod studyPeriod) {
+            return new StudyPeriodDto(studyPeriod.getStartDate(), studyPeriod.getEndDate());
+        }
+    }
+
+    public static StudyDetailResponse of(Study study, StudyMember studyMember) {
+        return new StudyDetailResponse(
+                study.getId(),
+                study.getName().getValue(),
+                StudyPeriodDto.from(study.getPeriod()),
+                study.getTopic().getValue(),
+                study.getInviteCode().getValue(),
+                studyMember.getRole()
+        );
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/api/dto/StudyDetailResponse.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/StudyDetailResponse.java
@@ -7,11 +7,11 @@ import econovation.moongtaengi.study.domain.StudyRole;
 import java.time.LocalDate;
 
 public record StudyDetailResponse(
-        Long id,
-        String name,
-        StudyPeriodDto period,
-        String topic,
-        String inviteCode,
+        Long studyId,
+        String studyName,
+        StudyPeriodDto studyPeriod,
+        String studyTopic,
+        String studyInviteCode,
         StudyRole myRole
 ) {
     public record StudyPeriodDto(

--- a/src/main/java/econovation/moongtaengi/study/application/StudyDetailService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/StudyDetailService.java
@@ -1,0 +1,24 @@
+package econovation.moongtaengi.study.application;
+
+import econovation.moongtaengi.study.api.dto.StudyDetailResponse;
+import econovation.moongtaengi.study.domain.StudyErrorCode;
+import econovation.moongtaengi.study.domain.StudyException;
+import econovation.moongtaengi.study.domain.StudyMember;
+import econovation.moongtaengi.study.domain.StudyMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyDetailService {
+    private final StudyMemberRepository studyMemberRepository;
+
+    public StudyDetailResponse getStudyDetail(Long studyId, Long memberId) {
+        StudyMember studyMember = studyMemberRepository.findByStudyIdAndMemberId(studyId, memberId)
+                .orElseThrow(() -> new StudyException(StudyErrorCode.NOT_STUDY_MEMBER));
+
+        return StudyDetailResponse.of(studyMember.getStudy(), studyMember);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyMemberRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyMemberRepository.java
@@ -1,6 +1,7 @@
 package econovation.moongtaengi.study.domain;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -8,4 +9,7 @@ import org.springframework.data.repository.query.Param;
 public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> {
     @Query("select sm from StudyMember sm join fetch sm.study where sm.memberId = :memberId and sm.role = :role")
     List<StudyMember> findAllByMemberIdAndRole(@Param("memberId") Long memberId, @Param("role") StudyRole role);
+
+    @Query("select sm from StudyMember sm join fetch sm.study where sm.study.id = :studyId and sm.memberId = :memberId")
+    Optional<StudyMember> findByStudyIdAndMemberId(@Param("studyId") Long studyId, @Param("memberId") Long memberId);
 }

--- a/src/test/java/econovation/moongtaengi/study/api/StudyControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/StudyControllerTest.java
@@ -6,8 +6,10 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,10 +18,14 @@ import econovation.moongtaengi.global.security.CustomAuthentication;
 import econovation.moongtaengi.global.security.JwtTokenProvider;
 import econovation.moongtaengi.global.security.LoginMemberIdArgumentResolver;
 import econovation.moongtaengi.study.api.dto.StudyCreateRequest;
+import econovation.moongtaengi.study.api.dto.StudyDetailResponse;
+import econovation.moongtaengi.study.api.dto.StudyDetailResponse.StudyPeriodDto;
 import econovation.moongtaengi.study.api.dto.StudyJoinRequest;
 import econovation.moongtaengi.study.application.CreateStudyService;
 import econovation.moongtaengi.study.application.JoinStudyService;
+import econovation.moongtaengi.study.application.StudyDetailService;
 import econovation.moongtaengi.study.domain.StudyJoinValidator;
+import econovation.moongtaengi.study.domain.StudyRole;
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -51,6 +57,8 @@ public class StudyControllerTest {
     private JoinStudyService joinStudyService;
     @MockitoBean
     private StudyJoinValidator studyJoinValidator;
+    @MockitoBean
+    private StudyDetailService studyDetailService;
 
     @BeforeEach
     void setUp() {
@@ -121,5 +129,42 @@ public class StudyControllerTest {
                 .andExpect(status().isOk());
 
         verify(joinStudyService).joinStudy(eq(1L), eq(rawCode));
+    }
+
+    @Test
+    @DisplayName("스터디 상세 조회 성공 시 200 OK와 상세 정보를 반환한다.")
+    void 스터디_상세_조회_성공() throws Exception {
+        //given
+        Long studyId = 100L;
+        Long memberId = 1L;
+
+        StudyDetailResponse.StudyPeriodDto periodDto = new StudyPeriodDto(
+                LocalDate.of(2026, 1, 8),
+                LocalDate.of(2026, 3, 21)
+        );
+
+        StudyDetailResponse response = new StudyDetailResponse(
+                studyId,
+                "테스트 스터디",
+                periodDto,
+                "테스트 주제",
+                "12345678",
+                StudyRole.HOST
+        );
+        given(studyDetailService.getStudyDetail(studyId, memberId))
+                .willReturn(response);
+
+        //when&then
+        mvc.perform(get("/api/studies/{studyId}", studyId)
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(studyId))
+                .andExpect(jsonPath("$.name").value("테스트 스터디"))
+                .andExpect(jsonPath("$.topic").value("테스트 주제"))
+                .andExpect(jsonPath("$.period.startDate").value("2026-01-08"))
+                .andExpect(jsonPath("$.period.endDate").value("2026-03-21"));
+
+        verify(studyDetailService).getStudyDetail(studyId, memberId);
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/api/StudyControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/StudyControllerTest.java
@@ -159,11 +159,11 @@ public class StudyControllerTest {
                     .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(studyId))
-                .andExpect(jsonPath("$.name").value("테스트 스터디"))
-                .andExpect(jsonPath("$.topic").value("테스트 주제"))
-                .andExpect(jsonPath("$.period.startDate").value("2026-01-08"))
-                .andExpect(jsonPath("$.period.endDate").value("2026-03-21"));
+                .andExpect(jsonPath("$.studyId").value(studyId))
+                .andExpect(jsonPath("$.studyName").value("테스트 스터디"))
+                .andExpect(jsonPath("$.studyTopic").value("테스트 주제"))
+                .andExpect(jsonPath("$.studyPeriod.startDate").value("2026-01-08"))
+                .andExpect(jsonPath("$.studyPeriod.endDate").value("2026-03-21"));
 
         verify(studyDetailService).getStudyDetail(studyId, memberId);
     }

--- a/src/test/java/econovation/moongtaengi/study/application/StudyDetailServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/StudyDetailServiceTest.java
@@ -1,0 +1,86 @@
+package econovation.moongtaengi.study.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import econovation.moongtaengi.study.api.dto.StudyDetailResponse;
+import econovation.moongtaengi.study.domain.InviteCode;
+import econovation.moongtaengi.study.domain.Study;
+import econovation.moongtaengi.study.domain.StudyErrorCode;
+import econovation.moongtaengi.study.domain.StudyException;
+import econovation.moongtaengi.study.domain.StudyMember;
+import econovation.moongtaengi.study.domain.StudyMemberRepository;
+import econovation.moongtaengi.study.domain.StudyName;
+import econovation.moongtaengi.study.domain.StudyPeriod;
+import econovation.moongtaengi.study.domain.StudyRole;
+import econovation.moongtaengi.study.domain.StudyTopic;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class StudyDetailServiceTest {
+    @InjectMocks
+    private StudyDetailService studyDetailService;
+
+    @Mock
+    private StudyMemberRepository studyMemberRepository;
+
+    @Test
+    @DisplayName("studyId와 memberId를 통해 스터디 상세 조회에 성공한다.")
+    void 스터디_상세_조회_성공() {
+        //given
+        Long memberId = 1L;
+        Long studyId = 100L;
+        LocalDate startDate = LocalDate.of(2026, 1, 8);
+        LocalDate endDate = LocalDate.of(2026, 3, 20);
+        Study study = new Study(
+                new StudyName("테스트 스터디"),
+                new StudyPeriod(startDate, endDate),
+                new StudyTopic("테스트 주제"),
+                memberId,
+                new InviteCode("12345678")
+        );
+        ReflectionTestUtils.setField(study, "id", studyId);
+
+        StudyMember studyMember = new StudyMember(study, memberId, StudyRole.HOST);
+        given(studyMemberRepository.findByStudyIdAndMemberId(studyId, memberId))
+                .willReturn(Optional.of(studyMember));
+
+        //when
+        StudyDetailResponse result = studyDetailService.getStudyDetail(studyId, memberId);
+
+        //then
+        assertThat(result.id()).isEqualTo(studyId);
+        assertThat(result.name()).isEqualTo("테스트 스터디");
+
+        assertThat(result.period().startDate()).isEqualTo(startDate);
+        assertThat(result.period().endDate()).isEqualTo(endDate);
+
+        assertThat(result.myRole()).isEqualTo(StudyRole.HOST);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 스터디거나 스터디의 멤버가 아니면 예외가 발생한다.")
+    void 스터디_멤버_아님_실패() {
+        //given
+        Long studyId = 999L;
+        Long strangerId = 999L;
+
+        given(studyMemberRepository.findByStudyIdAndMemberId(studyId, strangerId))
+                .willReturn(Optional.empty());
+
+        //when&then
+        assertThatThrownBy(() -> studyDetailService.getStudyDetail(studyId, strangerId))
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.NOT_STUDY_MEMBER);
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/application/StudyDetailServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/StudyDetailServiceTest.java
@@ -58,11 +58,11 @@ public class StudyDetailServiceTest {
         StudyDetailResponse result = studyDetailService.getStudyDetail(studyId, memberId);
 
         //then
-        assertThat(result.id()).isEqualTo(studyId);
-        assertThat(result.name()).isEqualTo("테스트 스터디");
+        assertThat(result.studyId()).isEqualTo(studyId);
+        assertThat(result.studyName()).isEqualTo("테스트 스터디");
 
-        assertThat(result.period().startDate()).isEqualTo(startDate);
-        assertThat(result.period().endDate()).isEqualTo(endDate);
+        assertThat(result.studyPeriod().startDate()).isEqualTo(startDate);
+        assertThat(result.studyPeriod().endDate()).isEqualTo(endDate);
 
         assertThat(result.myRole()).isEqualTo(StudyRole.HOST);
     }

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyMemberRepositoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyMemberRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import jakarta.persistence.PersistenceUnitUtil;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,6 +46,40 @@ public class StudyMemberRepositoryTest {
 
         PersistenceUnitUtil util = entityManager.getEntityManager().getEntityManagerFactory().getPersistenceUnitUtil();
         boolean isLoaded = util.isLoaded(result.getFirst().getStudy());
+
+        assertThat(isLoaded).isTrue();
+    }
+
+    @Test
+    @DisplayName("스터디 ID와 회원 ID로 조회 시, 스터디 엔티티까지 fetch join으로 한 번에 가져온다.")
+    void 스터디ID_회원ID_조회_성공() {
+        // given
+        Long memberId = 1L;
+        Study study = new Study(
+                new StudyName("테스트 스터디"),
+                new StudyPeriod(LocalDate.now(), LocalDate.now().plusDays(7)),
+                new StudyTopic("테스트 주제"),
+                memberId,
+                new InviteCode("12345678")
+        );
+        entityManager.persist(study);
+        entityManager.flush();
+
+        Long studyId = study.getId();
+        entityManager.clear();
+
+        // when
+        Optional<StudyMember> optionalResult = studyMemberRepository.findByStudyIdAndMemberId(studyId, memberId);
+
+        // then
+        assertThat(optionalResult).isPresent();
+        StudyMember result = optionalResult.get();
+        assertThat(result.getMemberId()).isEqualTo(memberId);
+        assertThat(result.getStudy().getId()).isEqualTo(studyId);
+        assertThat(result.getStudy().getName().getValue()).isEqualTo("테스트 스터디");
+
+        PersistenceUnitUtil util = entityManager.getEntityManager().getEntityManagerFactory().getPersistenceUnitUtil();
+        boolean isLoaded = util.isLoaded(result.getStudy());
 
         assertThat(isLoaded).isTrue();
     }


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
1. 스터디 상세 조회 API 구현 (`GET /api/studies/{studyId}`)
- 스터디 ID를 기반으로 스터디의 상세 정보(이름, 주제, 기간 등)를 조회하는 엔드포인트를 구현
- `@LoginMemberId` 를 통해 요청한 회원의 ID를 주입받아 처리

2. N+1문제 최적화
- 스터디 상세 조회 시 `StudyMember`를 통해 권한을 확인하고 `Study` 정보를 가져오는 과정에서 N+1 문제가 발생할 우려가 있음.
- `StudyMemberRepository`에 `JOIN FETCH`를 적용한 `findByStudyIdAndMemberId` 메서드를 구현하여, 단 1회의 쿼리로 멤버 정보와 스터디 정보를 함께 로딩하도록 최적화
- `PersistenceUnitUtil`을 활용한 테스트 코드를 통해 Fetch Join이 실제로 동작하여 연관 엔티티가 로딩되었는지 검증

3. 비즈니스 로직 및 DTO 설계
- 상세 조회 로직의 응집도를 높이기 위해 기존 서비스와 분리하여 `StudyDetailService`를 별도로 구현
- 조회 시 회원의 `StudyRole`(HOST, GUEST)을 함께 반환하여 프론트엔드에서 권한별 UI(수정/삭제 버튼 등)를 제어할 수 있도록 설계
- 예외 처리: 존재하지 않는 스터디거나 멤버가 아닌 경우 `NOT_STUDY_MEMBER` 예외를 발생시킴
- DTO 구조: StudyDetailResponse에서 VO(`StudyPeriod`)를 `StudyPeriodDto`(nested)로 변환하여 응답하도록 구현

4. 테스트
- Repository: `findByStudyIdAndMemberId`Fetch Join 동작 검증 테스트
- Service: Mockito를 활용한 getStudyDetail(성공/실패 케이스) 단위 테스트
- Controller: `WebMvcTest`를 활용한 API 엔드포인트 '/api/studies/{studyId}` 및 StudyDetialResponse 검증 테스트
### 🧪 테스트 결과
<img width="517" height="326" alt="image" src="https://github.com/user-attachments/assets/4b50d83e-7ed7-4931-8d3a-16fc49bbd84c" />
<img width="517" height="613" alt="image" src="https://github.com/user-attachments/assets/09480462-42ba-48b8-89ac-d8157aab4a3d" />


### 👿 트러블 슈팅
1. N+1 문제 방지를 위한 조회 전략 변경
 - 문제 상황: 스터디 상세 조회 시, Study 엔티티를 먼저 조회하고 그 안의 members 리스트를 순회하며 "내가 이 스터디의 멤버인지(권한)" 확인하려 함.
   - 이 경우 스터디원이 많아지면 불필요한 멤버 데이터까지 모두 로딩해야 하며, 연관 관계 설정에 따라 N+1 문제가 발생할 위험이 있음.

  - 해결: 조회 주체를 Study가 아닌 StudyMember로 변경함.
    - StudyMemberRepository.findByStudyIdAndMemberId 메서드를 구현.
    - JOIN FETCH를 적용하여 StudyMember 조회 시 Study 정보까지 단 1회의 쿼리로 가져오도록 최적화.
### 💬 코멘트
getStudyDetail 메서드에서 StudyMemberRepository의 findByStudyIdAndMemberId로 스터디의 멤버인지(권한이 있는지)를 확인하였습니다. 
그런데 이게 복잡한 로직 없이 쉽게 권한을 확인할 수 있을 것 같아 이렇게 구현했는데 문제점이 예외처리가 구체적으로 되지는 않게 됩니다..
찾아보니까 보안적으로 오히려 사용자에게 스터디가 있는지 없는지 권한이 있는지 없는지 구체적으로 알려주는 것보다 그냥 권한없음 처리로 하는 것도 좋을 수 있다곤 합니다. (github 같은 경우는 저희와 반대로 그냥 404만 띄운다고 합니다)


