### PR TITLE
fix: CORS 설정에 Location 헤더 노출 추가

### DIFF
--- a/src/main/java/econovation/moongtaengi/global/security/config/SecurityConfig.java
+++ b/src/main/java/econovation/moongtaengi/global/security/config/SecurityConfig.java
@@ -73,6 +73,7 @@ public class SecurityConfig {
         configuration.setAllowedOriginPatterns(Collections.singletonList("*"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Collections.singletonList("*"));
+        configuration.setExposedHeaders(Collections.singletonList("Location"));
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();


### PR DESCRIPTION
### 📌 PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
SecurityConfig의 CORS 설정(corsConfigurationSource)을 수정
  - 응답 헤더 중 Location을 프론트엔드에서 읽을 수 있도록 ExposedHeaders 설정을 추가
### 🧪 테스트 결과
1. Postman으로 스터디 생성 API 요청 헤더 설정 (브라우저 요청으로 보내도록) 
<img width="721" height="53" alt="image" src="https://github.com/user-attachments/assets/9744e02b-d4cc-4173-a878-c335379d15f2" />
<img width="559" height="41" alt="image" src="https://github.com/user-attachments/assets/3c8f7bdd-4a07-4d5b-9297-086142acff02" />

2. 응답 헤더 확인
<img width="567" height="139" alt="image" src="https://github.com/user-attachments/assets/824b46ee-134b-4c61-8e64-06fa0328ef04" />

### 👿 트러블 슈팅
스터디 생성 API 호출 후 201 Created 응답 시, 서버는 Location 헤더에 생성된 리소스 URI를 담아 보내고 있음
하지만 브라우저 보안 정책(CORS)으로 인해, 프론트엔드(JS)에서 해당 헤더 값(Location)에 접근할 수 없는 문제가 발생
-> 이를 해결하기 위해 서버에서 명시적으로 해당 헤더의 노출을 허용
### 💬 코멘트



