### PR TITLE
feat: 스터디 정보 수정 기능 및 기간 유효성 검증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,4 +46,5 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	systemProperty "user.timezone", "Asia/Seoul"
 }

--- a/src/main/java/econovation/moongtaengi/study/api/StudyController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/StudyController.java
@@ -4,15 +4,19 @@ import econovation.moongtaengi.global.annotation.LoginMemberId;
 import econovation.moongtaengi.study.api.dto.StudyCreateRequest;
 import econovation.moongtaengi.study.api.dto.StudyDetailResponse;
 import econovation.moongtaengi.study.api.dto.StudyJoinRequest;
+import econovation.moongtaengi.study.api.dto.StudyUpdateRequest;
 import econovation.moongtaengi.study.application.CreateStudyService;
 import econovation.moongtaengi.study.application.JoinStudyService;
 import econovation.moongtaengi.study.application.StudyDetailService;
+import econovation.moongtaengi.study.application.UpdateStudyCommand;
+import econovation.moongtaengi.study.application.UpdateStudyService;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,6 +31,7 @@ public class StudyController {
     private final CreateStudyService createStudyService;
     private final JoinStudyService joinStudyService;
     private final StudyDetailService studyDetailService;
+    private final UpdateStudyService updateStudyService;
 
     @PostMapping
     public ResponseEntity<Void> createStudy(
@@ -66,5 +71,20 @@ public class StudyController {
         log.info("스터디 상 조회 API 호출 - memberId: {}, studyId: {}", memberId, studyId);
 
         return ResponseEntity.ok(studyDetailService.getStudyDetail(studyId, memberId));
+    }
+
+    @PatchMapping("/{studyId}")
+    public ResponseEntity<Void> updateStudy(
+            @LoginMemberId Long memberId,
+            @PathVariable Long studyId,
+            @RequestBody StudyUpdateRequest request
+    ) {
+        log.info("스터디 수정 API 호출 - memberId: {}, studyId: {}", memberId, studyId);
+
+        UpdateStudyCommand command = request.toCommand(memberId, studyId);
+
+        updateStudyService.updateStudy(command);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/api/dto/StudyUpdateRequest.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/StudyUpdateRequest.java
@@ -1,0 +1,22 @@
+package econovation.moongtaengi.study.api.dto;
+
+import econovation.moongtaengi.study.application.UpdateStudyCommand;
+import java.time.LocalDate;
+
+public record StudyUpdateRequest(
+        String name,
+        String topic,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+    public UpdateStudyCommand toCommand(Long memberId, Long studyId) {
+        return new UpdateStudyCommand(
+                memberId,
+                studyId,
+                this.name,
+                this.topic,
+                this.startDate,
+                this.endDate
+        );
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/application/UpdateStudyCommand.java
+++ b/src/main/java/econovation/moongtaengi/study/application/UpdateStudyCommand.java
@@ -1,0 +1,13 @@
+package econovation.moongtaengi.study.application;
+
+import java.time.LocalDate;
+
+public record UpdateStudyCommand(
+        Long memberId,
+        Long studyId,
+        String name,
+        String topic,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+}

--- a/src/main/java/econovation/moongtaengi/study/application/UpdateStudyService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/UpdateStudyService.java
@@ -43,5 +43,8 @@ public class UpdateStudyService {
         studyPeriodValidator.validate(study.getId(), period);
 
         study.update(command.memberId(), name, period, topic);
+
+        log.info("스터디 정보 수정 완료 - memberId: {}, studyId: {}, studyName: {}",
+                command.memberId(), study.getId(), study.getName().getValue());
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/application/UpdateStudyService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/UpdateStudyService.java
@@ -1,0 +1,47 @@
+package econovation.moongtaengi.study.application;
+
+import econovation.moongtaengi.study.domain.Study;
+import econovation.moongtaengi.study.domain.StudyErrorCode;
+import econovation.moongtaengi.study.domain.StudyException;
+import econovation.moongtaengi.study.domain.StudyName;
+import econovation.moongtaengi.study.domain.StudyPeriod;
+import econovation.moongtaengi.study.domain.StudyPeriodValidator;
+import econovation.moongtaengi.study.domain.StudyRepository;
+import econovation.moongtaengi.study.domain.StudyTopic;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UpdateStudyService {
+    private final StudyRepository studyRepository;
+    private final StudyPeriodValidator studyPeriodValidator;
+
+    @Transactional
+    public void updateStudy(UpdateStudyCommand command) {
+        Study study = studyRepository.findByIdWithMembers(command.studyId())
+                .orElseThrow(() -> new StudyException(StudyErrorCode.STUDY_NOT_FOUND));
+
+        StudyName name = command.name() != null ?
+                new StudyName(command.name()) : study.getName();
+
+        StudyTopic topic = command.topic() != null ?
+                new StudyTopic(command.topic()) : study.getTopic();
+
+        LocalDate startDate = command.startDate() != null ?
+                command.startDate() : study.getPeriod().getStartDate();
+
+        LocalDate endDate = command.endDate() != null ?
+                command.endDate() : study.getPeriod().getEndDate();
+
+        StudyPeriod period = new StudyPeriod(startDate, endDate);
+
+        studyPeriodValidator.validate(study.getId(), period);
+
+        study.update(command.memberId(), name, period, topic);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/Study.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/Study.java
@@ -50,6 +50,14 @@ public class Study extends BaseEntity {
         members.add(studyMember);
     }
 
+    public void update(Long memberId, StudyName name, StudyPeriod period, StudyTopic topic) {
+        validateHost(memberId);
+
+        this.name = name;
+        this.period = period;
+        this.topic = topic;
+    }
+
     /**
      * 호스트 권한 검증
      */
@@ -61,7 +69,7 @@ public class Study extends BaseEntity {
                 );
 
         if (!isHost) {
-            throw new StudyException(StudyErrorCode.UNAUTHORIZED_PROCESS_ACCESS);
+            throw new StudyException(StudyErrorCode.NOT_STUDY_HOST);
         }
     }
 

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyErrorCode.java
@@ -56,7 +56,11 @@ public enum StudyErrorCode implements ErrorCode {
     STUDY_JOIN_DENIED_TEMP_MEMBER(HttpStatus.FORBIDDEN, "STUDY_022", "임시회원은 스터디를 참여할 수 없습니다."),
  
     // 프로세스
-    PROCESS_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY_019", "존재하지 않는 프로세스입니다.");
+    PROCESS_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY_019", "존재하지 않는 프로세스입니다."),
+
+    //스터디 기간 수정 제한
+    STUDY_START_DATE_TOO_LATE(HttpStatus.BAD_REQUEST, "STUDY_023","스터디 시작일은 첫 번째 프로세스 시작일보다 빨라야 합니다."),
+    STUDY_END_DATE_TOO_EARLY(HttpStatus.BAD_REQUEST, "STUDY_024","스터디 종료일은 마지막 프로세스 종료일보다 늦어야 합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyErrorCode.java
@@ -29,7 +29,7 @@ public enum StudyErrorCode implements ErrorCode {
     TOPIC_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "STUDY_010", "스터디 주제는 최대 %d자까지만 가능합니다."),
 
     // 스터디 권한
-    UNAUTHORIZED_PROCESS_ACCESS(HttpStatus.FORBIDDEN, "STUDY_011", "프로세스 생성/수정/삭제 권한이 없습니다. 호스트만 가능합니다."),
+    NOT_STUDY_HOST(HttpStatus.FORBIDDEN, "STUDY_011", "스터디 방장 권한이 필요합니다."),
    
     //스터디 참여 중복
     ALREADY_JOINED_MEMBER(HttpStatus.CONFLICT, "STUDY_012", "이미 참여 중인 스터디입니다."),

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyPeriodValidator.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyPeriodValidator.java
@@ -1,0 +1,28 @@
+package econovation.moongtaengi.study.domain;
+
+import econovation.moongtaengi.study.domain.process.StudyProcessPeriodBound;
+import econovation.moongtaengi.study.domain.process.StudyProcessRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StudyPeriodValidator {
+    private final StudyProcessRepository studyProcessRepository;
+
+    public void validate(Long studyId, StudyPeriod newPeriod) {
+        StudyProcessPeriodBound bound = studyProcessRepository.findProcessPeriodBound(studyId);
+
+        if (bound.minStartDate() == null || bound.maxEndDate() == null) {
+            return;
+        }
+
+        if (newPeriod.getEndDate().isBefore(bound.maxEndDate())) {
+            throw new StudyException(StudyErrorCode.STUDY_END_DATE_TOO_EARLY);
+        }
+
+        if (newPeriod.getStartDate().isAfter(bound.minStartDate())) {
+            throw new StudyException(StudyErrorCode.STUDY_START_DATE_TOO_LATE);
+        }
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyRepository.java
@@ -12,4 +12,7 @@ public interface StudyRepository extends JpaRepository<Study, Long> {
     boolean existsByInviteCodeValue(String value);
 
     Optional<Study> findByInviteCode(InviteCode inviteCode);
+
+    @Query("SELECT s FROM Study s JOIN FETCH s.members WHERE s.id = :id")
+    Optional<Study> findByIdWithMembers(@Param("id") Long id);
 }

--- a/src/main/java/econovation/moongtaengi/study/domain/process/StudyProcessPeriodBound.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/process/StudyProcessPeriodBound.java
@@ -1,0 +1,9 @@
+package econovation.moongtaengi.study.domain.process;
+
+import java.time.LocalDate;
+
+public record StudyProcessPeriodBound(
+        LocalDate minStartDate,
+        LocalDate maxEndDate
+) {
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/process/StudyProcessRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/process/StudyProcessRepository.java
@@ -1,6 +1,8 @@
 package econovation.moongtaengi.study.domain.process;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -28,4 +30,14 @@ public interface StudyProcessRepository extends JpaRepository<StudyProcess, Long
      * 스터디 ID로 프로세스 전체 삭제
      */
     void deleteByStudyId(Long studyId);
+
+    @Query("""
+        SELECT new econovation.moongtaengi.study.domain.process.StudyProcessPeriodBound(
+            MIN(sp.period.startDate),
+            MAX(sp.period.endDate)
+        )
+        FROM StudyProcess sp
+        WHERE sp.studyId = :studyId
+    """)
+    StudyProcessPeriodBound findProcessPeriodBound(@Param("studyId") Long studyId);
 }

--- a/src/test/java/econovation/moongtaengi/study/api/StudyControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/StudyControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -15,15 +16,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import econovation.moongtaengi.global.config.WebConfig;
 import econovation.moongtaengi.global.security.CustomAuthentication;
-import econovation.moongtaengi.global.security.JwtTokenProvider;
 import econovation.moongtaengi.global.security.LoginMemberIdArgumentResolver;
 import econovation.moongtaengi.study.api.dto.StudyCreateRequest;
 import econovation.moongtaengi.study.api.dto.StudyDetailResponse;
 import econovation.moongtaengi.study.api.dto.StudyDetailResponse.StudyPeriodDto;
 import econovation.moongtaengi.study.api.dto.StudyJoinRequest;
+import econovation.moongtaengi.study.api.dto.StudyUpdateRequest;
 import econovation.moongtaengi.study.application.CreateStudyService;
 import econovation.moongtaengi.study.application.JoinStudyService;
 import econovation.moongtaengi.study.application.StudyDetailService;
+import econovation.moongtaengi.study.application.UpdateStudyCommand;
+import econovation.moongtaengi.study.application.UpdateStudyService;
 import econovation.moongtaengi.study.domain.StudyJoinValidator;
 import econovation.moongtaengi.study.domain.StudyRole;
 import java.time.LocalDate;
@@ -59,6 +62,8 @@ public class StudyControllerTest {
     private StudyJoinValidator studyJoinValidator;
     @MockitoBean
     private StudyDetailService studyDetailService;
+    @MockitoBean
+    private UpdateStudyService updateStudyService;
 
     @BeforeEach
     void setUp() {
@@ -166,5 +171,38 @@ public class StudyControllerTest {
                 .andExpect(jsonPath("$.studyPeriod.endDate").value("2026-03-21"));
 
         verify(studyDetailService).getStudyDetail(studyId, memberId);
+    }
+
+    @Test
+    @DisplayName("스터디 정보 수정 요청 시 Command로 변환하여 서비스를 호출하고 200 OK를 반환한다")
+    void 스터디_수정_성공() throws Exception {
+        //given
+        Long memberId = 1L;
+        Long studyId = 100L;
+
+        StudyUpdateRequest request = new StudyUpdateRequest(
+                "수정된 이름",
+                "수정된 주제",
+                LocalDate.of(2026, 1, 10),
+                LocalDate.of(2026, 1, 28)
+        );
+
+        //when&then
+        mvc.perform(patch("/api/studies/{studyId}", studyId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        UpdateStudyCommand expectedCommand = new UpdateStudyCommand(
+                memberId,
+                studyId,
+                request.name(),
+                request.topic(),
+                request.startDate(),
+                request.endDate()
+        );
+
+        verify(updateStudyService).updateStudy(eq(expectedCommand));
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/application/UpdateStudyServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/UpdateStudyServiceTest.java
@@ -1,0 +1,136 @@
+package econovation.moongtaengi.study.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import econovation.moongtaengi.study.domain.InviteCode;
+import econovation.moongtaengi.study.domain.Study;
+import econovation.moongtaengi.study.domain.StudyErrorCode;
+import econovation.moongtaengi.study.domain.StudyException;
+import econovation.moongtaengi.study.domain.StudyName;
+import econovation.moongtaengi.study.domain.StudyPeriod;
+import econovation.moongtaengi.study.domain.StudyPeriodValidator;
+import econovation.moongtaengi.study.domain.StudyRepository;
+import econovation.moongtaengi.study.domain.StudyTopic;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class UpdateStudyServiceTest {
+    @InjectMocks
+    private UpdateStudyService updateStudyService;
+
+    @Mock
+    private StudyRepository studyRepository;
+
+    @Mock
+    private StudyPeriodValidator studyPeriodValidator;
+
+    @Test
+    @DisplayName("방장은 스터디 정보를 수정할 수 있다. (일부 필드만 수정 시 기존 값 유지)")
+    void 스터디_수정_성공() {
+        //given
+        Long hostId = 1L;
+        Long studyId = 100L;
+
+        Study study = createStudy(hostId, studyId);
+
+        given(studyRepository.findByIdWithMembers(studyId))
+                .willReturn(Optional.of(study));
+
+        UpdateStudyCommand command = new UpdateStudyCommand(
+                hostId,
+                studyId,
+                "수정된 이름",
+                null,
+                LocalDate.of(2026, 1, 10),
+                LocalDate.of(2026, 1, 20));
+
+        //when
+        updateStudyService.updateStudy(command);
+
+        //then
+        verify(studyPeriodValidator).validate(eq(studyId), any(StudyPeriod.class));
+        assertThat(study.getName().getValue()).isEqualTo("수정된 이름");
+        assertThat(study.getTopic().getValue()).isEqualTo("테스트 주제");
+        assertThat(study.getPeriod().getStartDate()).isEqualTo(LocalDate.of(2026, 1, 10));
+        assertThat(study.getPeriod().getEndDate()).isEqualTo(LocalDate.of(2026, 1, 20));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 스터디를 수정하려 하면 예외가 발생한다.")
+    void 스터디_없음_예외() {
+        //given
+        Long hostId = 1L;
+        Long studyId = 999L;
+        given(studyRepository.findByIdWithMembers(studyId))
+                .willReturn(Optional.empty());
+
+        UpdateStudyCommand command = new UpdateStudyCommand(
+                hostId,
+                studyId,
+                "수정된 이름",
+                "수정된 주제",
+                LocalDate.now(),
+                LocalDate.now()
+        );
+
+        //when&then
+        assertThatThrownBy(() -> updateStudyService.updateStudy(command))
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.STUDY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("방장이 아닌 멤버가 수정을 시도하면 예외가 발생한다.(도메인 예외 전파 테스트)")
+    void 스터디_수정_실패_권한없음() {
+        //given
+        Long hostId = 1L;
+        Long guestId = 50L;
+        Long studyId = 100L;
+        Study study = createStudy(hostId, studyId);
+        study.addGuest(guestId);
+
+        given(studyRepository.findByIdWithMembers(studyId))
+                .willReturn(Optional.of(study));
+
+        UpdateStudyCommand command = new UpdateStudyCommand(
+                guestId,
+                studyId,
+                "수정된 이름",
+                "수정된 주제",
+                LocalDate.now(),
+                LocalDate.now()
+        );
+
+        //when&then
+        assertThatThrownBy(() -> updateStudyService.updateStudy(command))
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.NOT_STUDY_HOST);
+    }
+
+    private Study createStudy(Long hostId, Long studyId) {
+        Study study = new Study(
+                new StudyName("테스트 이름"),
+                new StudyPeriod(LocalDate.now(), LocalDate.now().plusDays(7)),
+                new StudyTopic("테스트 주제"),
+                hostId,
+                new InviteCode("12345678")
+        );
+        ReflectionTestUtils.setField(study, "id", studyId);
+        return study;
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyPeriodValidatorTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyPeriodValidatorTest.java
@@ -1,0 +1,94 @@
+package econovation.moongtaengi.study.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.BDDMockito.given;
+
+import econovation.moongtaengi.study.domain.process.StudyProcessPeriodBound;
+import econovation.moongtaengi.study.domain.process.StudyProcessRepository;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class StudyPeriodValidatorTest {
+    @InjectMocks
+    private StudyPeriodValidator studyPeriodValidator;
+
+    @Mock
+    private StudyProcessRepository studyProcessRepository;
+
+    @Test
+    @DisplayName("스터디 기간이 프로세스 기간을 모두 포함할 때 예외를 던지지 않는다.")
+    void 검증_성공() {
+        //given
+        Long studyId = 1L;
+
+        StudyProcessPeriodBound bound = new StudyProcessPeriodBound(
+                LocalDate.of(2026, 1, 10),
+                LocalDate.of(2026, 1, 20)
+        );
+        given(studyProcessRepository.findProcessPeriodBound(studyId)).willReturn(bound);
+
+
+        StudyPeriod newPeriod = new StudyPeriod(
+                LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 1, 30)
+        );
+
+        //when&then
+        assertDoesNotThrow(() -> studyPeriodValidator.validate(studyId, newPeriod));
+    }
+
+    @Test
+    @DisplayName("스터디 종료일이 프로세스 종료일보다 빠를 때 예외를 던진다.")
+    void 종료일_짧음_검증_실패() {
+        //given
+        Long studyId = 1L;
+
+        StudyProcessPeriodBound bound = new StudyProcessPeriodBound(
+                LocalDate.of(2026, 1, 10),
+                LocalDate.of(2026, 1, 20)
+        );
+        given(studyProcessRepository.findProcessPeriodBound(studyId)).willReturn(bound);
+
+        StudyPeriod newPeriod = new StudyPeriod(
+                LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 1, 19)
+        );
+
+        //when&then
+        assertThatThrownBy(() -> studyPeriodValidator.validate(studyId, newPeriod))
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.STUDY_END_DATE_TOO_EARLY);
+    }
+
+    @Test
+    @DisplayName("스터디 시작일이 프로세스 시작일보다 늦을 때 예외를 던진다.")
+    void 시작일_늦음_검증_실패() {
+        //given
+        Long studyId = 1L;
+
+        StudyProcessPeriodBound bound = new StudyProcessPeriodBound(
+                LocalDate.of(2026, 1, 10),
+                LocalDate.of(2026, 1, 20)
+        );
+        given(studyProcessRepository.findProcessPeriodBound(studyId)).willReturn(bound);
+
+        StudyPeriod newPeriod = new StudyPeriod(
+                LocalDate.of(2026, 1, 11),
+                LocalDate.of(2026, 1, 30)
+        );
+
+        //when&then
+        assertThatThrownBy(() -> studyPeriodValidator.validate(studyId, newPeriod))
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.STUDY_START_DATE_TOO_LATE);
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyProcessRepositoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyProcessRepositoryTest.java
@@ -1,0 +1,64 @@
+package econovation.moongtaengi.study.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import econovation.moongtaengi.study.domain.process.StudyProcess;
+import econovation.moongtaengi.study.domain.process.StudyProcessPeriodBound;
+import econovation.moongtaengi.study.domain.process.StudyProcessRepository;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+public class StudyProcessRepositoryTest {
+    @Autowired
+    private StudyProcessRepository studyProcessRepository;
+
+    @Test
+    @DisplayName("스터디 ID로 조회 시 프로세스들의 전체 기간(시작~종료) 경계를 반환한다")
+    void 프로세스_기간_경계_조회() {
+        //given
+        Long studyId = 1L;
+
+        createAndSaveProcess(studyId, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 10));
+        createAndSaveProcess(studyId, LocalDate.of(2026, 1, 11), LocalDate.of(2026, 1, 20));
+        createAndSaveProcess(studyId, LocalDate.of(2026, 1, 21), LocalDate.of(2026, 1, 30));
+
+        //when
+        StudyProcessPeriodBound bound = studyProcessRepository.findProcessPeriodBound(studyId);
+
+        //then
+        assertThat(bound).isNotNull();
+        assertThat(bound.minStartDate()).isEqualTo(LocalDate.of(2026, 1, 1));
+        assertThat(bound.maxEndDate()).isEqualTo(LocalDate.of(2026, 1, 30));
+    }
+
+    @Test
+    @DisplayName("프로세스가 없으면 null을 반환한다 (min/max 결과가 null임)")
+    void 프로세스_없음() {
+        //given
+        Long emptyStudyId = 999L;
+
+        //when
+        StudyProcessPeriodBound bound = studyProcessRepository.findProcessPeriodBound(emptyStudyId);
+
+        //then
+        assertThat(bound.minStartDate()).isNull();
+        assertThat(bound.maxEndDate()).isNull();
+    }
+
+    private void createAndSaveProcess(Long studyId, LocalDate startDate, LocalDate endDate) {
+        StudyProcess studyProcess = StudyProcess.create(
+                studyId,
+                1,
+                "테스트 프로세스",
+                startDate,
+                endDate,
+                "테스트 과제 설명"
+        );
+
+        studyProcessRepository.save(studyProcess);
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyProcessRepositoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyProcessRepositoryTest.java
@@ -16,11 +16,22 @@ public class StudyProcessRepositoryTest {
     @Autowired
     private StudyProcessRepository studyProcessRepository;
 
+    @Autowired
+    private StudyRepository studyRepository;
+
     @Test
     @DisplayName("스터디 ID로 조회 시 프로세스들의 전체 기간(시작~종료) 경계를 반환한다")
     void 프로세스_기간_경계_조회() {
         //given
-        Long studyId = 1L;
+        Study study = new Study(
+                new StudyName("테스트 이름"),
+                new StudyPeriod(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 30)),
+                new StudyTopic("테스트 주제"),
+                1L,
+                new InviteCode("12345678")
+        );
+        studyRepository.save(study);
+        Long studyId = study.getId();
 
         createAndSaveProcess(studyId, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 10));
         createAndSaveProcess(studyId, LocalDate.of(2026, 1, 11), LocalDate.of(2026, 1, 20));
@@ -39,7 +50,7 @@ public class StudyProcessRepositoryTest {
     @DisplayName("프로세스가 없으면 null을 반환한다 (min/max 결과가 null임)")
     void 프로세스_없음() {
         //given
-        Long emptyStudyId = 999L;
+        Long emptyStudyId = 99999L;
 
         //when
         StudyProcessPeriodBound bound = studyProcessRepository.findProcessPeriodBound(emptyStudyId);

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyRepositoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyRepositoryTest.java
@@ -9,11 +9,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 @DataJpaTest
 public class StudyRepositoryTest {
     @Autowired
     private StudyRepository studyRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
 
     @Test
     @DisplayName("초대 코드로 스터디를 조회할 수 있다.")
@@ -42,6 +46,31 @@ public class StudyRepositoryTest {
 
         //then
         assertThat(result).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("ID로 스터디 조회 시 멤버들도 Fetch Join으로 함께 조회한다.")
+    void 스터디_멤버_페치조인_조회() {
+        //given
+        InviteCode inviteCode = new InviteCode("12345678");
+        Study study = createStudyWithInviteCode(inviteCode);
+        studyRepository.save(study);
+
+        study.addGuest(2L);
+        studyRepository.save(study);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        //when
+        Optional<Study> result = studyRepository.findByIdWithMembers(study.getId());
+
+        //then
+        assertThat(result).isPresent();
+        assertThat(result.get().getMembers()).hasSize(2);
+        assertThat(result.get().getMembers())
+                .extracting("memberId")
+                .contains(1L, 2L);
     }
 
     private Study createStudyWithInviteCode(InviteCode inviteCode) {

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyTest.java
@@ -60,6 +60,46 @@ public class StudyTest {
                 .isEqualTo(StudyErrorCode.ALREADY_JOINED_MEMBER);
     }
 
+    @Test
+    @DisplayName("방장은 스터디 정보를 수정할 수 있다.")
+    void 스터디_수정_성공() {
+        //given
+        Long hostId = 1L;
+        Study study = createStudy(hostId);
+
+        StudyName newName = new StudyName("변경된 이름");
+        StudyTopic newTopic = new StudyTopic("변경된 주제");
+        StudyPeriod newPeriod = new StudyPeriod(LocalDate.of(2026, 2, 1), LocalDate.of(2026, 2, 28));
+
+        //when
+        study.update(hostId, newName, newPeriod, newTopic);
+
+        //then
+        assertThat(study.getName()).isEqualTo(newName);
+        assertThat(study.getTopic()).isEqualTo(newTopic);
+        assertThat(study.getPeriod()).isEqualTo(newPeriod);
+    }
+
+    @Test
+    @DisplayName("방장이 아닌 회원이 수정을 시도하면 예외가 발생한다.")
+    void 스터디_수정_실패_권한없음() {
+        //given
+        Long hostId = 1L;
+        Long guestId = 2L;
+        Study study = createStudy(hostId);
+        study.addGuest(guestId);
+
+        StudyName newName = new StudyName("변경된 이름");
+        StudyTopic newTopic = new StudyTopic("변경된 주제");
+        StudyPeriod newPeriod = new StudyPeriod(LocalDate.now(), LocalDate.now().plusDays(7));
+
+        //when&then
+        assertThatThrownBy(() -> study.update(guestId, newName, newPeriod, newTopic))
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.NOT_STUDY_HOST);
+    }
+
     private Study createStudy(Long hostId) {
         return new Study(
                 new StudyName("테스트 스터디"),


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->
close #42 
### 🧑‍💻 구현한 내용
**Domain Layer (Repository 포함)**

- Study: 스터디 정보 수정 메서드(update) 구현(방장 권한 선행 검증)
- StudyPeriodValidator: 스터디 기간 변경 시 내부 프로세스 기간을 벗어나느지 여부를 검증하는 도메인 서비스 구현
- StudyProcessPeriodBound: 프로세스들의 최소 시작일과 최대 종료일을 담는 도메인 프로젝션 정의
- 검증 실패 원인을 명확히 알리기 위해 구체적인 에러 코드 정의(TOO_LATE, TOO_EARLY, NOT_STUDY_HOST)
- Repository:
  - StudyRepository: 수정 권한 검증 시 N+1 방지를 위해 JOIN FETCH를 적용한 findByIdWithMembers 구현
  - StudyProcessRepository: 단일 JPQL 쿼리로 Min/Max 기간을 조회하는 findProcessPeriodBound 구현
- Tests:
  - StudyTest: 수정 로직 성공 및 권한 예외 발생 검증
  - StudyPeriodValidatorTest: 기간 경계값 및 프로세스 부재 시 동작 검증
  - StudyRepositoryTest: TestEntityManager를 활용하여 페치 조인 동작 검증
  - StudyProcessRepositoryTest: 기간 경계 조회 정확성 검증

**Application Layer**

- UpdateStudyService: 스터디 정보 수정 비즈니스 로직 구현 및 트랜잭션 처리
- API 계층과의 결합도를 낮추기 위해 서비스 전용 모델인 UpdateStudyCommand 정의 및 적용
- 입력값의 null 여부를 판단하여 값이 있는 경우에만 변경하는 Patch 로직 수행 및 Validator 협력 조율
- 정상 수정 완료 시 (memberId, studyId, studyName) 로깅
- Tests:
  - UpdateStudyServiceTest: command 객체를 활용한 성공, 권한 없음, 스터디 없음 시나리오 단위 테스트

**Presentation Layer**

- StudyController: PATCH /api/studies/{studyId} 엔드포인트 구현 및 @LoginMemberId 적용
- StudyUpdateRequest: 수정 요청 DTO 내부에 Command 변환 팩토리 메서드(toCommand) 구현
- Tests:
  - StudyControllerTest: MockMvc를 활용한 API 성공 및 서비스 계층 Command 전달 검증
### 🧪 테스트 결과
테스트코드 모두 통과하였습니다! 

<img width="541" height="250" alt="image" src="https://github.com/user-attachments/assets/e8330ed6-e1d8-4435-86ed-26a5f16132c0" />
<img width="541" height="210" alt="image" src="https://github.com/user-attachments/assets/93791735-02c8-4ee5-8cc7-4787138c6f8f" />


### 👿 트러블 슈팅
**1. 계층 간 의존성 위반 해결 (DTO vs Command)**

- 문제 상황: 초기에는 편의성을 위해 Service 계층에서 Controller의 객체인 `StudyUpdateRequest`(DTO)를 직접 파라미터로 받도록 설계함.
-> application 계층이 Presentation에 의존하게 되어, 계층형 아키텍처의 의존성 규칙을 위반함.
- 해결 과정:
  - 모든 필드를 개별 인자로 풀어서 넘기기엔 파라미터 개수가 과도해짐.
  - Service 전용 입력 모델인 `UpdateStudyCommand`를 도입하여 계층 간 결합을 끊고, 순수한 비즈니스 로직을 유지함.

**2. PATCH 방식의 Null 처리(부분 수정) 책임 분리**

- 고민 포인트: PATCH 요청 특성상 `null`로 들어온 필드는 기존 값을 유지해야 함. 이 분기 처리(`if null`)를 Service와 Domain 중 어디서 수행할지 갈등.
- Trade-off:
  - Domain 처리 시: application 레이어가 매우 얇아지나, 엔티티가 입력값이 없을 때 유지한다는 프레젠테이션 계층의 데이터 사정(API 스펙)까지 알게 되어 순수성이 오염됨.
  - Service 처리 시: application 레이어가 다소 늘어나지만, 도메인 엔티티는 완성된 데이터만 받아 확실하게 상태를 변경할 수 있음.
- 최종 결정: application 레이어에서 처리.
  - 서비스가 기존 데이터와 입력 데이터를 조합하여 완전한 상태의 값을 만든 뒤, 엔티티에게 전달하는 방식을 택함. 이를 통해 엔티티의 순수성을 확보함.
### 💬 코멘트
프로세스 기간까지 생각해야 하다보니 시간이 걸렸습니다.. 


