### PR TITLE
feat: Assignment 도메인 모델 및 테스트 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/Assignment.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/Assignment.java
@@ -3,6 +3,8 @@ package econovation.moongtaengi.study.domain.assignment;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -33,11 +35,20 @@ public class Assignment {
     @Embedded
     private AssignmentDeadline deadline;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private AssignmentStatus status;
+
+    @Column(name = "is_late", nullable = false)
+    private boolean isLate;
+
     private Assignment(Long processId, Long assigneeId, AssignmentContent content, AssignmentDeadline deadline) {
         this.processId = processId;
         this.assigneeId = assigneeId;
         this.content = content;
         this.deadline = deadline;
+        this.status = AssignmentStatus.WAITING;
+        this.isLate = false;
     }
 
     @Builder
@@ -45,6 +56,11 @@ public class Assignment {
         validate(processId, assigneeId, content, deadline);
 
         return new Assignment(processId, assigneeId, content, deadline);
+    }
+
+    public void markAsSubmitted(boolean isLate) {
+        this.status = AssignmentStatus.SUBMITTED;
+        this.isLate = isLate;
     }
 
     private static void validate(Long processId, Long assigneeId, AssignmentContent content, AssignmentDeadline deadline) {

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/Assignment.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/Assignment.java
@@ -1,5 +1,6 @@
 package econovation.moongtaengi.study.domain.assignment;
 
+import econovation.moongtaengi.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -18,11 +19,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "assignments")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Assignment {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+public class Assignment extends BaseEntity {
     @Column(name = "process_id", nullable = false)
     private Long processId;
 

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/Assignment.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/Assignment.java
@@ -1,0 +1,55 @@
+package econovation.moongtaengi.study.domain.assignment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "assignments")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Assignment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "process_id", nullable = false)
+    private Long processId;
+
+    @Column(name = "assignee_id", nullable = false)
+    private Long assigneeId;
+
+    @Embedded
+    private AssignmentContent content;
+
+    @Embedded
+    private AssignmentDeadline deadline;
+
+    private Assignment(Long processId, Long assigneeId, AssignmentContent content, AssignmentDeadline deadline) {
+        this.processId = processId;
+        this.assigneeId = assigneeId;
+        this.content = content;
+        this.deadline = deadline;
+    }
+
+    @Builder
+    public static Assignment create(Long processId, Long assigneeId, AssignmentContent content, AssignmentDeadline deadline) {
+        validate(processId, assigneeId, content, deadline);
+
+        return new Assignment(processId, assigneeId, content, deadline);
+    }
+
+    private static void validate(Long processId, Long assigneeId, AssignmentContent content, AssignmentDeadline deadline) {
+        if (processId == null || assigneeId == null || content == null || deadline == null) {
+            throw new AssignmentException(AssignmentErrorCode.INVALID_ASSIGNMENT_INFO);
+        }
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentContent.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentContent.java
@@ -1,0 +1,34 @@
+package econovation.moongtaengi.study.domain.assignment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+public class AssignmentContent {
+    private static final int MAX_LENGTH = 300;
+
+    @Column(name = "content", nullable = false, length = MAX_LENGTH)
+    private String value;
+
+    public AssignmentContent(String value) {
+        validate(value);
+        this.value = value.trim();
+    }
+
+    private void validate(String value) {
+        if (value == null || value.isBlank()) {
+            throw new AssignmentException(AssignmentErrorCode.INVALID_ASSIGNMENT_INFO);
+        }
+
+        if (value.trim().length() > MAX_LENGTH) {
+            throw new AssignmentException(AssignmentErrorCode.INVALID_ASSIGNMENT_INFO);
+        }
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentDeadline.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentDeadline.java
@@ -1,0 +1,44 @@
+package econovation.moongtaengi.study.domain.assignment;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+public class AssignmentDeadline {
+    @Column(name = "deadline", nullable = false)
+    private LocalDateTime value;
+
+    private AssignmentDeadline(LocalDateTime value) {
+        this.value = value;
+    }
+
+    public static AssignmentDeadline create(
+            LocalDateTime requestDate,
+            LocalDate startDate,
+            LocalDate endDate) {
+        LocalDateTime rangeStart = startDate.atStartOfDay();
+        LocalDateTime rangeEnd = endDate.atTime(23, 59, 59);
+
+        LocalDateTime targetDate = (requestDate != null) ? requestDate : rangeEnd;
+
+        validate(targetDate, rangeStart, rangeEnd);
+
+        return new AssignmentDeadline(targetDate);
+    }
+
+    private static void validate(LocalDateTime targetDate, LocalDateTime rangeStart, LocalDateTime rangeEnd) {
+        if (targetDate.isBefore(rangeStart) || targetDate.isAfter(rangeEnd)) {
+            throw new AssignmentException(AssignmentErrorCode.INVALID_ASSIGNMENT_INFO);
+        }
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentErrorCode.java
@@ -1,0 +1,16 @@
+package econovation.moongtaengi.study.domain.assignment;
+
+import econovation.moongtaengi.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AssignmentErrorCode implements ErrorCode {
+    INVALID_ASSIGNMENT_INFO(HttpStatus.BAD_REQUEST, "AS_001", "과제 정보가 올바르지 않습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentException.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentException.java
@@ -1,0 +1,11 @@
+package econovation.moongtaengi.study.domain.assignment;
+
+import econovation.moongtaengi.global.exception.BusinessException;
+import econovation.moongtaengi.global.exception.ErrorCode;
+
+public class AssignmentException extends BusinessException {
+
+    public AssignmentException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentStatus.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentStatus.java
@@ -1,8 +1,5 @@
 package econovation.moongtaengi.study.domain.assignment;
 
-
-
-
 public enum AssignmentStatus {
     WAITING,
     SUBMITTED,

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentStatus.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentStatus.java
@@ -1,0 +1,10 @@
+package econovation.moongtaengi.study.domain.assignment;
+
+
+
+
+public enum AssignmentStatus {
+    WAITING,
+    SUBMITTED,
+    APPROVED
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentFixture.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentFixture.java
@@ -1,0 +1,26 @@
+package econovation.moongtaengi.study.domain.assignment;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class AssignmentFixture {
+    public static final Long DEFAULT_PROCESS_ID = 1L;
+    public static final Long DEFAULT_ASSIGNEE_ID = 1L;
+    public static final AssignmentContent DEFAULT_CONTENT = new AssignmentContent("테스트 내용");
+
+    public static Assignment.AssignmentBuilder anAssignment() {
+        LocalDate processStartDate = LocalDate.now();
+        LocalDate processEndDate = processStartDate.plusDays(14);
+        LocalDateTime requestDeadline = processStartDate.plusDays(7).atStartOfDay();
+
+        return Assignment.builder()
+                .processId(DEFAULT_PROCESS_ID)
+                .assigneeId(DEFAULT_ASSIGNEE_ID)
+                .content(DEFAULT_CONTENT)
+                .deadline(AssignmentDeadline.create(
+                        requestDeadline,
+                        processStartDate,
+                        processEndDate
+                ));
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentTest.java
@@ -34,4 +34,20 @@ public class AssignmentTest {
         assertThat(assignment.getContent())
                 .isEqualTo(AssignmentFixture.DEFAULT_CONTENT);
     }
+
+    @Test
+    @DisplayName("과제 제출 시 상태가 SUBMITTED로 변경되고, 지각 여부가 기록된다.")
+    void 과제_제출_상태_변경_지각_여부_기록_성공() {
+        //given
+        Assignment assignment = anAssignment()
+                .build();
+
+        //when
+        boolean isLate = true;
+        assignment.markAsSubmitted(isLate);
+
+        //then
+        assertThat(assignment.getStatus()).isEqualTo(AssignmentStatus.SUBMITTED);
+        assertThat(assignment.isLate()).isTrue();
+    }
 }

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentTest.java
@@ -1,0 +1,37 @@
+package econovation.moongtaengi.study.domain.assignment;
+
+import static econovation.moongtaengi.study.domain.assignment.AssignmentFixture.anAssignment;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class AssignmentTest {
+    @Test
+    @DisplayName("기본 픽스처로 생성 성공")
+    void create_success_fixture() {
+        //when
+        Assignment assignment = anAssignment().build();
+
+        //then
+        assertThat(assignment.getContent())
+                .isEqualTo(AssignmentFixture.DEFAULT_CONTENT);
+    }
+
+    @Test
+    @DisplayName("특정 담당자에게 개별 과제를 성공적으로 생성한다")
+    void 과제_생성_성공() {
+        //given
+        Long newAssigneeId = 10L;
+
+        //when
+        Assignment assignment = anAssignment()
+                .assigneeId(newAssigneeId)
+                .build();
+
+        //then
+        assertThat(assignment.getAssigneeId()).isEqualTo(newAssigneeId);
+        assertThat(assignment.getContent())
+                .isEqualTo(AssignmentFixture.DEFAULT_CONTENT);
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentVOTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentVOTest.java
@@ -1,0 +1,107 @@
+package econovation.moongtaengi.study.domain.assignment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+public class AssignmentVOTest {
+    @Nested
+    @DisplayName("과제 내용")
+    class AssignmentTitleTest {
+        @Test
+        @DisplayName("과제 내용을 성공적으로 생성한다.")
+        void 과제_내용_성공() {
+            String value = "테스트 내용";
+            AssignmentContent description = new AssignmentContent(value);
+
+            assertThat(description.getValue()).isEqualTo(value);
+        }
+
+        @Test
+        @DisplayName("앞뒤 공백은 자동으로 제거된다.")
+        void 과제_내용_공백_제거() {
+            String value = "  공백이 많은 내용  ";
+            AssignmentContent title = new AssignmentContent(value);
+
+            assertThat(title.getValue()).isEqualTo("공백이 많은 내용");
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @DisplayName("과제 내용은 null이거나 비어있을 수 없다")
+        void 과제_내용_비었음_실패(String invalidInput) {
+            assertThatThrownBy(() -> new AssignmentContent(invalidInput))
+                    .isInstanceOf(AssignmentException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(AssignmentErrorCode.INVALID_ASSIGNMENT_INFO);
+        }
+
+        @Test
+        @DisplayName("과제 내용은 300자를 초과할 수 없다")
+        void 과제_내용_초과_실패() {
+            String longContent = "뭉".repeat(400);
+
+            assertThatThrownBy(() -> new AssignmentContent(longContent))
+                    .isInstanceOf(AssignmentException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(AssignmentErrorCode.INVALID_ASSIGNMENT_INFO);
+        }
+    }
+
+    @Nested
+    @DisplayName("과제 마감일")
+    class AssignmentDeadlineTest {
+
+        @Test
+        @DisplayName("마감일 생성 성공 (기간 내 포함)")
+        void 마감일_생성_성공() {
+            //given
+            LocalDate startDate = LocalDate.of(2026, 1, 1);
+            LocalDate endDate = LocalDate.of(2026, 1, 31);
+            LocalDateTime targetDate = LocalDateTime.of(2026, 1, 15, 12, 0);
+
+            //when
+            AssignmentDeadline deadline = AssignmentDeadline.create(targetDate, startDate, endDate);
+
+            //then
+            assertThat(deadline.getValue()).isEqualTo(targetDate);
+        }
+
+        @Test
+        @DisplayName("마감일이 null이면 프로세스 종료일의 마지막 시간으로 자동 설정된다")
+        void 마감일_자동_생성_성공() {
+            //given
+            LocalDate startDate = LocalDate.of(2026, 1, 1);
+            LocalDate endDate = LocalDate.of(2026, 1, 31);
+            LocalDateTime expectedDefault = LocalDateTime.of(2026, 1, 31, 23, 59, 59);
+
+            //when
+            AssignmentDeadline deadline = AssignmentDeadline.create(null, startDate, endDate);
+
+            //then
+            assertThat(deadline.getValue()).isEqualTo(expectedDefault);
+        }
+
+        @Test
+        @DisplayName("마감일이 프로세스 기간을 벗어나면 예외가 발생한다")
+        void 마감일_프로세스_기간_벗어남_실패() {
+            //given
+            LocalDate startDate = LocalDate.of(2026, 1, 1);
+            LocalDate endDate = LocalDate.of(2026, 1, 31);
+            LocalDateTime outOfRangeDate = LocalDateTime.of(2026, 2, 1, 0, 0);
+
+            //when&then
+            assertThatThrownBy(() -> AssignmentDeadline.create(outOfRangeDate, startDate, endDate))
+                    .isInstanceOf(AssignmentException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(AssignmentErrorCode.INVALID_ASSIGNMENT_INFO);
+        }
+    }
+}


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
Assignment Entity 구현 (정적 팩토리 메서드 도입)
- 정적 팩토리 메서드(`create`)에 `@Builder` 적용: 생성자는 단순 필드 할당만 담당하도록 `private`으로 제한하고, 객체 생성의 진입점을 `create` 메서드로 통일
- 검증 로직 추가: `create` 메서드 내부에서 `validate`를 호출하여 `processId`, `assigneeId` 및 VO들이 `null`인 경우 예외를 발생시키도록 구현. 이를 통해 불완전한 객체가 생성되는 것을 차단.
- VO 분리: `AssignmentContent`, `AssignmentDeadline`을 구현하여 상태 검증 책임을 분리.
- 에러코드추가: `AssignmentErrorCode` 추가 및 `AssignmentException` 구현
- 상태 관리 로직 추가: AssignmentStatus(WAITING, SUBMITTED, APPROVED)와 isLate 필드를 추가하고, markAsSubmitted 메서드를 통해 제출 시 상태 변경 책임을 엔티티에 부여함.

AssignmentDeadline 비즈니스 로직
- 마감일 자동 설정 정책: 과제 생성 시 마감일이 주어지지 않으면(`null`), 해당 프로세스종료일(End Date)을 자동으로 마감 기한으로 설정
- 유효성 검증: 마감일이 프로세스 기간(시작일~종료일)을 벗어날 경우 `INVALID_ASSIGNMENT_INFO` 예외가 발생

AssignmentContent 캡슐화
- 과제 내용의 길이 제한(300자) 및 공백 검증 로직을 VO 내부로 캡슐화

테스트 및 Fixture
- AssignmentFixture: 팩토리 메서드 패턴 변경에 맞춰, 내부에서 VO를 조립한 뒤 `Assignment.builder()`를 호출하도록 구현
- 단위 테스트 :
  -  `AssignmentTest`: 엔티티 생성, validate 검증, 연관관계 매핑 및 과제 제출 상태 변경(markAsSubmitted) 로직 테스트
  - `AssignmentVOTest`: 날짜 계산, 길이 제한 등 세부 도메인 로직 검증
### 🧪 테스트 결과
- [x] 테스트 코드 모두 통과하였습니다!!
### 👿 트러블 슈팅
정적 팩토리 메서드 설계 변경
고민: 초기에는 생성자에 @Builder를 붙였으나, null 검증 로직이 생성자 내부에 섞이면서 코드가 지저분해짐.
해결: 생성자는 private으로 닫아두고, 정적 팩토리 메서드(create)를 열어 여기서 검증(validate)을 수행한 뒤 객체를 생성하도록 구조를 변경하여 관심사를 분리.

### 💬 코멘트
전체적으로 설계 끝났다고 생각해서 금방 구현할 줄 알았는데 막상 코드로 구현하려고 하니까 이것저것 생각이 많이 들어서 느리게 개발되었습니다.. pr 단위 작게 가져가면서 빠르게 하나 하나 끝내는 식으로 구현해보겠습니다!


