### PR TITLE
feat: 칭호, 경험치(EXP), 퀘스트 로직 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/member/application/AuthService.java
+++ b/src/main/java/econovation/moongtaengi/member/application/AuthService.java
@@ -1,12 +1,13 @@
 package econovation.moongtaengi.member.application;
 
 import econovation.moongtaengi.global.security.JwtTokenProvider;
-import econovation.moongtaengi.member.domain.QuestType;
+import econovation.moongtaengi.member.domain.event.LoginSuccessEvent;
 import econovation.moongtaengi.member.infra.oauth.KakaoOAuthClient;
 import econovation.moongtaengi.member.domain.Member;
 import econovation.moongtaengi.member.domain.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,7 +20,7 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final KakaoOAuthClient kakaoOAuthClient;
     private final JwtTokenProvider jwtTokenProvider;
-    private final ExperienceService experienceService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public KakaoLoginResponse loginWithKakao(String code) {
@@ -33,7 +34,7 @@ public class AuthService {
         String accessToken = jwtTokenProvider.createAccessToken(member.getId());
 
         if (member.isActive()) {
-            experienceService.completeQuest(member.getId(), QuestType.LOGIN);
+            eventPublisher.publishEvent(new LoginSuccessEvent(member.getId()));
         }
 
         log.info("로그인 성공 - memberId: {}, needsInfo: {}",

--- a/src/main/java/econovation/moongtaengi/member/application/AuthService.java
+++ b/src/main/java/econovation/moongtaengi/member/application/AuthService.java
@@ -1,6 +1,7 @@
 package econovation.moongtaengi.member.application;
 
 import econovation.moongtaengi.global.security.JwtTokenProvider;
+import econovation.moongtaengi.member.domain.QuestType;
 import econovation.moongtaengi.member.infra.oauth.KakaoOAuthClient;
 import econovation.moongtaengi.member.domain.Member;
 import econovation.moongtaengi.member.domain.MemberRepository;
@@ -18,6 +19,7 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final KakaoOAuthClient kakaoOAuthClient;
     private final JwtTokenProvider jwtTokenProvider;
+    private final ExperienceService experienceService;
 
     @Transactional
     public KakaoLoginResponse loginWithKakao(String code) {
@@ -29,6 +31,10 @@ public class AuthService {
                 .orElseGet(() -> createTemporaryMember(kakaoId));
 
         String accessToken = jwtTokenProvider.createAccessToken(member.getId());
+
+        if (member.isActive()) {
+            experienceService.completeQuest(member.getId(), QuestType.LOGIN);
+        }
 
         log.info("로그인 성공 - memberId: {}, needsInfo: {}",
                 member.getId(), member.isTemporary());

--- a/src/main/java/econovation/moongtaengi/member/application/ExperienceEventListener.java
+++ b/src/main/java/econovation/moongtaengi/member/application/ExperienceEventListener.java
@@ -5,8 +5,11 @@ import econovation.moongtaengi.member.domain.event.LoginSuccessEvent;
 import econovation.moongtaengi.study.domain.event.StudyCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
@@ -14,13 +17,15 @@ import org.springframework.stereotype.Component;
 public class ExperienceEventListener {
     private final ExperienceService experienceService;
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleLoginSuccess(LoginSuccessEvent event) {
         log.info("LoginSuccessEvent 수신 - memberId: {}", event.memberId());
         experienceService.completeQuest(event.memberId(), QuestType.LOGIN);
     }
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleStudyCreated(StudyCreatedEvent event) {
         log.info("StudyCreatedEvent 수신 - studyId: {}, memberId: {}", event.studyId(), event.memberId());
         experienceService.completeQuest(event.memberId(), QuestType.CREATE_STUDY);

--- a/src/main/java/econovation/moongtaengi/member/application/ExperienceEventListener.java
+++ b/src/main/java/econovation/moongtaengi/member/application/ExperienceEventListener.java
@@ -1,0 +1,28 @@
+package econovation.moongtaengi.member.application;
+
+import econovation.moongtaengi.member.domain.QuestType;
+import econovation.moongtaengi.member.domain.event.LoginSuccessEvent;
+import econovation.moongtaengi.study.domain.event.StudyCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExperienceEventListener {
+    private final ExperienceService experienceService;
+
+    @EventListener
+    public void handleLoginSuccess(LoginSuccessEvent event) {
+        log.info("LoginSuccessEvent 수신 - memberId: {}", event.memberId());
+        experienceService.completeQuest(event.memberId(), QuestType.LOGIN);
+    }
+
+    @EventListener
+    public void handleStudyCreated(StudyCreatedEvent event) {
+        log.info("StudyCreatedEvent 수신 - studyId: {}, memberId: {}", event.studyId(), event.memberId());
+        experienceService.completeQuest(event.memberId(), QuestType.CREATE_STUDY);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/member/application/ExperienceService.java
+++ b/src/main/java/econovation/moongtaengi/member/application/ExperienceService.java
@@ -1,0 +1,43 @@
+package econovation.moongtaengi.member.application;
+
+import econovation.moongtaengi.member.domain.DailyQuest;
+import econovation.moongtaengi.member.domain.DailyQuestRepository;
+import econovation.moongtaengi.member.domain.Member;
+import econovation.moongtaengi.member.domain.MemberRepository;
+import econovation.moongtaengi.member.domain.QuestType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ExperienceService {
+    private final MemberRepository memberRepository;
+    private final DailyQuestRepository dailyQuestRepository;
+
+    @Transactional
+    public void completeQuest(Long memberId, QuestType questType) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException());
+
+        DailyQuest dailyQuest = dailyQuestRepository
+                .findByMemberIdAndQuestType(memberId, questType)
+                .orElseGet(() -> DailyQuest.create(memberId, questType));
+
+        if (!dailyQuest.canComplete()) {
+            log.info("Member {} has already completed quest {} for today", memberId, questType);
+            return;
+        }
+
+        dailyQuest.complete();
+        member.addExperience(questType.getExperiencePoint());
+
+        dailyQuestRepository.save(dailyQuest);
+        memberRepository.save(member);
+
+        log.info("Member {} completed quest {} and earned {} XP. Total XP: {}",
+                memberId, questType, questType.getExperiencePoint(), member.getTotalExperience());
+    }
+}

--- a/src/main/java/econovation/moongtaengi/member/domain/DailyQuest.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/DailyQuest.java
@@ -1,0 +1,78 @@
+package econovation.moongtaengi.member.domain;
+
+import econovation.moongtaengi.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "daily_quests", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "quest_type"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyQuest extends BaseEntity {
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "quest_type", nullable = false)
+    private QuestType questType;
+
+    @Column(nullable = false)
+    private int completedCount = 0;
+
+    @Column(nullable = false)
+    private LocalDate lastCompletedDate;
+
+    @Builder
+    private DailyQuest(Long memberId, QuestType questType, int completedCount, LocalDate lastCompletedDate) {
+        this.memberId = memberId;
+        this.questType = questType;
+        this.completedCount = completedCount;
+        this.lastCompletedDate = lastCompletedDate;
+    }
+
+    public static DailyQuest create(Long memberId, QuestType questType) {
+        return DailyQuest.builder()
+                .memberId(memberId)
+                .questType(questType)
+                .completedCount(0)
+                .lastCompletedDate(LocalDate.now())
+                .build();
+    }
+
+    public boolean canComplete() {
+        resetIfNewDay();
+        return questType.canComplete(completedCount);
+    }
+
+    public void complete() {
+        if (!canComplete()) {
+            throw new IllegalStateException("일일 퀘스트 제한을 초과했습니다.");
+        }
+        this.completedCount++;
+        this.lastCompletedDate = LocalDate.now();
+    }
+
+    private void resetIfNewDay() {
+        LocalDate today = LocalDate.now();
+        if (!lastCompletedDate.equals(today) && questType.isDaily()) {
+            this.completedCount = 0;
+            this.lastCompletedDate = today;
+        }
+    }
+
+    public boolean isCompletedToday() {
+        return lastCompletedDate.equals(LocalDate.now()) && completedCount > 0;
+    }
+}

--- a/src/main/java/econovation/moongtaengi/member/domain/DailyQuestRepository.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/DailyQuestRepository.java
@@ -1,0 +1,13 @@
+package econovation.moongtaengi.member.domain;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DailyQuestRepository extends JpaRepository<DailyQuest, Long> {
+    Optional<DailyQuest> findByMemberIdAndQuestType(Long memberId, QuestType questType);
+
+    List<DailyQuest> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/econovation/moongtaengi/member/domain/Member.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/Member.java
@@ -30,6 +30,9 @@ public class Member extends BaseEntity {
     @Column(nullable = false, columnDefinition = "VARCHAR(255) DEFAULT 'USER'")
     private Role role = Role.USER;
 
+    @Column(nullable = false, columnDefinition = "INT DEFAULT 0")
+    private int totalExperience = 0;
+
     // 카카오 로그인 시 임시 회원 생성
     public static Member createTemporaryMember(String kakaoId) {
         Member member = new Member();
@@ -74,5 +77,16 @@ public class Member extends BaseEntity {
 
     public boolean isUser() {
         return this.role == Role.USER;
+    }
+
+    public Title getTitle() {
+        return Title.fromExperience(this.totalExperience);
+    }
+
+    public void addExperience(int experience) {
+        if (experience <= 0) {
+            throw new IllegalArgumentException("경험치는 0보다 커야 합니다.");
+        }
+        this.totalExperience += experience;
     }
 }

--- a/src/main/java/econovation/moongtaengi/member/domain/QuestType.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/QuestType.java
@@ -1,0 +1,26 @@
+package econovation.moongtaengi.member.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum QuestType {
+    COMMENT("댓글 작성", 2, 5, true),
+    SUBMIT_ASSIGNMENT("과제 제출", 10, 1, true),
+    REACTION("감정 표현", 1, 5, true),
+    CREATE_STUDY("스터디 생성", 20, 1, false),
+    LOGIN("로그인", 1, 1, true);
+
+    private final String displayName;
+    private final int experiencePoint;
+    private final int dailyLimit;
+    private final boolean isDaily;
+
+    public boolean canComplete(int currentCount) {
+        if (!isDaily) {
+            return currentCount == 0;
+        }
+        return currentCount < dailyLimit;
+    }
+}

--- a/src/main/java/econovation/moongtaengi/member/domain/Title.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/Title.java
@@ -1,0 +1,25 @@
+package econovation.moongtaengi.member.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Title {
+    BEGINNER("비기너", 0),
+    PRO("프로", 100),
+    MASTER("마스터", 300);
+
+    private final String displayName;
+    private final int requiredExperience;
+
+    public static Title fromExperience(int experience) {
+        if (experience >= MASTER.requiredExperience) {
+            return MASTER;
+        }
+        if (experience >= PRO.requiredExperience) {
+            return PRO;
+        }
+        return BEGINNER;
+    }
+}

--- a/src/main/java/econovation/moongtaengi/member/domain/event/LoginSuccessEvent.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/event/LoginSuccessEvent.java
@@ -1,0 +1,6 @@
+package econovation.moongtaengi.member.domain.event;
+
+public record LoginSuccessEvent(
+        Long memberId
+) {
+}

--- a/src/main/java/econovation/moongtaengi/study/application/CreateStudyService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/CreateStudyService.java
@@ -1,14 +1,14 @@
 package econovation.moongtaengi.study.application;
 
-import econovation.moongtaengi.member.application.ExperienceService;
-import econovation.moongtaengi.member.domain.QuestType;
 import econovation.moongtaengi.study.domain.Study;
 import econovation.moongtaengi.study.domain.StudyCreationValidator;
 import econovation.moongtaengi.study.domain.StudyFactory;
 import econovation.moongtaengi.study.domain.StudyRepository;
+import econovation.moongtaengi.study.domain.event.StudyCreatedEvent;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,7 +19,7 @@ public class CreateStudyService {
     private final StudyFactory studyFactory;
     private final StudyCreationValidator studyCreationValidator;
     private final StudyRepository studyRepository;
-    private final ExperienceService experienceService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public Long createStudy(Long memberId,
@@ -41,7 +41,7 @@ public class CreateStudyService {
         log.info("스터디 생성 성공 - studyId: {}, memberId: {}, inviteCode: {}",
                 study.getId(), memberId, study.getInviteCode().getValue());
 
-        experienceService.completeQuest(memberId, QuestType.CREATE_STUDY);
+        eventPublisher.publishEvent(new StudyCreatedEvent(study.getId(), memberId));
 
         return study.getId();
     }

--- a/src/main/java/econovation/moongtaengi/study/application/CreateStudyService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/CreateStudyService.java
@@ -1,5 +1,7 @@
 package econovation.moongtaengi.study.application;
 
+import econovation.moongtaengi.member.application.ExperienceService;
+import econovation.moongtaengi.member.domain.QuestType;
 import econovation.moongtaengi.study.domain.Study;
 import econovation.moongtaengi.study.domain.StudyCreationValidator;
 import econovation.moongtaengi.study.domain.StudyFactory;
@@ -17,6 +19,7 @@ public class CreateStudyService {
     private final StudyFactory studyFactory;
     private final StudyCreationValidator studyCreationValidator;
     private final StudyRepository studyRepository;
+    private final ExperienceService experienceService;
 
     @Transactional
     public Long createStudy(Long memberId,
@@ -37,6 +40,8 @@ public class CreateStudyService {
 
         log.info("스터디 생성 성공 - studyId: {}, memberId: {}, inviteCode: {}",
                 study.getId(), memberId, study.getInviteCode().getValue());
+
+        experienceService.completeQuest(memberId, QuestType.CREATE_STUDY);
 
         return study.getId();
     }

--- a/src/main/java/econovation/moongtaengi/study/domain/event/StudyCreatedEvent.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/event/StudyCreatedEvent.java
@@ -1,0 +1,7 @@
+package econovation.moongtaengi.study.domain.event;
+
+public record StudyCreatedEvent(
+        Long studyId,
+        Long memberId
+) {
+}

--- a/src/test/java/econovation/moongtaengi/study/application/CreateStudyTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/CreateStudyTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import econovation.moongtaengi.member.application.ExperienceService;
 import econovation.moongtaengi.study.api.dto.StudyCreateRequest;
 import econovation.moongtaengi.study.domain.InviteCode;
 import econovation.moongtaengi.study.domain.Study;
@@ -39,6 +40,9 @@ public class CreateStudyTest {
 
     @Mock
     private StudyRepository studyRepository;
+
+    @Mock
+    private ExperienceService experienceService;
 
     @InjectMocks
     private CreateStudyService createStudyService;

--- a/src/test/java/econovation/moongtaengi/study/application/CreateStudyTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/CreateStudyTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,7 +43,7 @@ public class CreateStudyTest {
     private StudyRepository studyRepository;
 
     @Mock
-    private ExperienceService experienceService;
+    private ApplicationEventPublisher applicationEventPublisher;
 
     @InjectMocks
     private CreateStudyService createStudyService;


### PR DESCRIPTION
### 📌 PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈

### 🧑‍💻 구현한 내용
1. 칭호(Title) 시스템
  - Title enum: BEGINNER(0xp), PRO(100xp), MASTER(300xp)
  - 경험치에 따라 자동으로 칭호가 결정됩니다

  2. 퀘스트(QuestType) 시스템
  5가지 퀘스트 타입과 보상:
  - COMMENT: 댓글 작성 (2xp, 하루 5회 제한)
  - SUBMIT_ASSIGNMENT: 과제 제출 (10xp, 하루 1회 제한)
  - REACTION: 감정 표현 (1xp, 하루 5회 제한)
  - CREATE_STUDY: 스터디 생성 (20xp, 계정당 1회만)
  - LOGIN: 로그인 (1xp, 하루 1회 제한)

  3. Member 엔티티 확장
  - totalExperience 필드 추가
  - getTitle() 메서드: 현재 경험치 기반 칭호 반환
  - addExperience(int) 메서드: 경험치 추가

  4. DailyQuest 엔티티
  - 일일 퀘스트 진행 상황 추적
  - 날짜가 바뀌면 자동으로 카운트 리셋
  - 일일 제한 체크 기능

  5. ExperienceService
  - completeQuest(): 퀘스트 완료 및 경험치 지급
  - 일일 제한 초과 시 경험치 지급하지 않음

  테스트 방법
  1. 회원가입 & 로그인
    - 카카오 로그인 후 최종 회원가입 완료 후 다시 로그인 시도
    - 로그인하면 1xp 획득 (하루 1번만)
  2. 스터디 생성
    - 스터디를 생성하면 20xp 획득 (계정당 1번만)
  3. 칭호 확인
    - 0~99xp: BEGINNER
    - 100~299xp: PRO
    - 300xp 이상: MASTER

### 🧪 테스트 결과

### 👿 트러블 슈팅

### 💬 코멘트
- 현재 과제와 관련된 로직이 미완성이여서 퀘스트와 알림 기능도 우선적으로 구현할 수 있는 부분만 우선 구현하겠습니다.
- 퀘스트 종류 5개 중 현재 로그인, 스터디 생성 시 퀘스트 달성하여 경험치 부여하도록 로직 구현한 상태입니다.
- 멤버 조회 시 현재 경험치와 현재 칭호를 응답으로 주도록 추가하겠습니다. 
- 추후에 일일 퀘스트 조회 API, 알림 기능 구현할 예정입니다.


