### PR TITLE
feat: processId 기반 과제 목록 조회 기능 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/api/AssignmentController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/AssignmentController.java
@@ -2,16 +2,21 @@ package econovation.moongtaengi.study.api;
 
 import econovation.moongtaengi.global.annotation.LoginMemberId;
 import econovation.moongtaengi.study.api.dto.AssignmentCreateRequest;
+import econovation.moongtaengi.study.application.assignment.AssignmentQueryService;
+import econovation.moongtaengi.study.application.assignment.AssignmentSummary;
 import econovation.moongtaengi.study.application.assignment.CreateAssignmentCommand;
 import econovation.moongtaengi.study.application.assignment.CreateAssignmentService;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -21,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AssignmentController {
 
     private final CreateAssignmentService createAssignmentService;
+    private final AssignmentQueryService assignmentQueryService;
 
     @PostMapping
     public ResponseEntity<Void> createAssignment(
@@ -39,5 +45,15 @@ public class AssignmentController {
 
         return ResponseEntity.created(URI.create("/api/assignments/" + assignmentId))
                 .build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<AssignmentSummary>> getAssignmentSummaries(
+            @LoginMemberId Long memberId,
+            @RequestParam Long processId
+    ) {
+        List<AssignmentSummary> response = assignmentQueryService.getAssignmentSummaries(memberId, processId);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentQueryService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentQueryService.java
@@ -1,0 +1,33 @@
+package econovation.moongtaengi.study.application.assignment;
+
+import econovation.moongtaengi.study.domain.StudyErrorCode;
+import econovation.moongtaengi.study.domain.StudyException;
+import econovation.moongtaengi.study.domain.StudyMemberRepository;
+import econovation.moongtaengi.study.domain.assignment.AssignmentRepository;
+import econovation.moongtaengi.study.domain.process.StudyProcessRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AssignmentQueryService {
+    private final AssignmentRepository assignmentRepository;
+    private final StudyProcessRepository processRepository;
+    private final StudyMemberRepository studyMemberRepository;
+
+    public List<AssignmentSummary> getAssignmentSummaries(Long memberId, Long processId) {
+        Long studyId = processRepository.findStudyIdById(processId)
+                .orElseThrow(() -> new StudyException(StudyErrorCode.PROCESS_NOT_FOUND));
+
+        boolean isMember = studyMemberRepository.existsByStudyIdAndMemberId(studyId, memberId);
+        if (!isMember) {
+            throw new StudyException(StudyErrorCode.NOT_STUDY_MEMBER);
+        }
+
+        return assignmentRepository.findSummaryByProcessIdAndStudyId(processId, studyId);
+    }
+
+}

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentSummary.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentSummary.java
@@ -9,6 +9,7 @@ public record AssignmentSummary(
         String assignmentContent,
         String nickname,
         AssignmentStatus status,
+        Boolean isLate,
         String fileUrl
 ) {
 

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentSummary.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentSummary.java
@@ -5,6 +5,7 @@ import econovation.moongtaengi.study.domain.assignment.AssignmentStatus;
 public record AssignmentSummary(
         Long assignmentId,
         Long submissionId,
+        Long memberId,
         String assignmentContent,
         String nickname,
         AssignmentStatus status,

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentSummary.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentSummary.java
@@ -1,0 +1,14 @@
+package econovation.moongtaengi.study.application.assignment;
+
+import econovation.moongtaengi.study.domain.assignment.AssignmentStatus;
+
+public record AssignmentSummary(
+        Long assignmentId,
+        Long submissionId,
+        String assignmentContent,
+        String nickname,
+        AssignmentStatus status,
+        String fileUrl
+) {
+
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepository.java
@@ -1,9 +1,34 @@
 package econovation.moongtaengi.study.domain.assignment;
 
+import econovation.moongtaengi.study.application.assignment.AssignmentSummary;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AssignmentRepository extends JpaRepository<Assignment, Long> {
     boolean existsByProcessIdAndAssigneeId(Long processId, Long assigneeId);
+
+    @Query("""
+        SELECT new econovation.moongtaengi.study.application.assignment.AssignmentSummary(
+            a.id,
+            s.id,
+            a.content.value,
+            m.nickname.value,
+            a.status,
+            sa.url
+        )
+        FROM StudyMember sm
+        JOIN Member m ON sm.memberId = m.id
+        LEFT JOIN Assignment a ON a.assigneeId = m.id AND a.processId = :processId
+        LEFT JOIN Submission s ON s.assignmentId = a.id AND s.submitterId = m.id
+        LEFT JOIN s.attachments sa
+        WHERE sm.study.id = :studyId
+    """)
+    List<AssignmentSummary> findSummaryByProcessIdAndStudyId(
+            @Param("processId") Long processId,
+            @Param("studyId") Long studyId
+    );
 }

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepository.java
@@ -15,6 +15,7 @@ public interface AssignmentRepository extends JpaRepository<Assignment, Long> {
         SELECT new econovation.moongtaengi.study.application.assignment.AssignmentSummary(
             a.id,
             s.id,
+            m.id,
             a.content.value,
             m.nickname.value,
             a.status,

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepository.java
@@ -19,6 +19,7 @@ public interface AssignmentRepository extends JpaRepository<Assignment, Long> {
             a.content.value,
             m.nickname.value,
             a.status,
+            a.isLate,
             sa.url
         )
         FROM StudyMember sm

--- a/src/main/java/econovation/moongtaengi/study/domain/process/StudyProcessRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/process/StudyProcessRepository.java
@@ -1,5 +1,6 @@
 package econovation.moongtaengi.study.domain.process;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -40,4 +41,7 @@ public interface StudyProcessRepository extends JpaRepository<StudyProcess, Long
         WHERE sp.studyId = :studyId
     """)
     StudyProcessPeriodBound findProcessPeriodBound(@Param("studyId") Long studyId);
+
+    @Query("SELECT p.studyId FROM StudyProcess p WHERE p.id = :processId")
+    Optional<Long> findStudyIdById(@Param("processId") Long processId);
 }

--- a/src/test/java/econovation/moongtaengi/study/api/AssignmentControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/AssignmentControllerTest.java
@@ -10,16 +10,22 @@ import econovation.moongtaengi.global.config.WebConfig;
 import econovation.moongtaengi.global.security.CustomAuthentication;
 import econovation.moongtaengi.global.security.LoginMemberIdArgumentResolver;
 import econovation.moongtaengi.study.api.dto.AssignmentCreateRequest;
+import econovation.moongtaengi.study.application.assignment.AssignmentQueryService;
+import econovation.moongtaengi.study.application.assignment.AssignmentSummary;
 import econovation.moongtaengi.study.application.assignment.CreateAssignmentCommand;
 import econovation.moongtaengi.study.application.assignment.CreateAssignmentService;
 
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import econovation.moongtaengi.study.domain.assignment.AssignmentStatus;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -51,6 +57,9 @@ public class AssignmentControllerTest {
 
     @MockitoBean
     private CreateAssignmentService createAssignmentService;
+
+    @MockitoBean
+    private AssignmentQueryService assignmentQueryService;
 
     @BeforeEach
     void setUp() {
@@ -153,5 +162,46 @@ public class AssignmentControllerTest {
                 Arguments.of("내용 누락(빈 문자열)", 99L, 1L, ""),
                 Arguments.of("내용 누락(공백)", 99L, 1L, "   ")
         );
+    }
+
+    @Test
+    @DisplayName("과제 목록 조회 요청 시, 서비스 호출 후 과제 요약 리스트를 반환한다")
+    void 과제_목록_조회_성공() throws Exception {
+        //given
+        Long memberId = 1L;
+        Long processId = 100L;
+
+        List<AssignmentSummary> summaries = List.of(
+                new AssignmentSummary(
+                        10L,
+                        1L,
+                        memberId,
+                        "알고리즘 과제",
+                        "지환", AssignmentStatus.SUBMITTED,
+                        "http://file.url"),
+                new AssignmentSummary(11L,
+                        null,
+                        2L,
+                        "JPA 과제",
+                        "철수",
+                        AssignmentStatus.WAITING,
+                        null)
+        );
+
+        given(assignmentQueryService.getAssignmentSummaries(memberId, processId))
+                .willReturn(summaries);
+
+        //when&then
+        mvc.perform(get("/api/assignments")
+                        .param("processId", String.valueOf(processId)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()").value(2))
+                .andExpect(jsonPath("$[0].nickname").value("지환"))
+                .andExpect(jsonPath("$[0].status").value("SUBMITTED"))
+                .andExpect(jsonPath("$[1].nickname").value("철수"))
+                .andExpect(jsonPath("$[1].status").value("WAITING"));
+
+        verify(assignmentQueryService).getAssignmentSummaries(memberId, processId);
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/api/AssignmentControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/AssignmentControllerTest.java
@@ -178,6 +178,7 @@ public class AssignmentControllerTest {
                         memberId,
                         "알고리즘 과제",
                         "지환", AssignmentStatus.SUBMITTED,
+                        false,
                         "http://file.url"),
                 new AssignmentSummary(11L,
                         null,
@@ -185,6 +186,7 @@ public class AssignmentControllerTest {
                         "JPA 과제",
                         "철수",
                         AssignmentStatus.WAITING,
+                        true,
                         null)
         );
 
@@ -199,8 +201,10 @@ public class AssignmentControllerTest {
                 .andExpect(jsonPath("$.size()").value(2))
                 .andExpect(jsonPath("$[0].nickname").value("지환"))
                 .andExpect(jsonPath("$[0].status").value("SUBMITTED"))
+                .andExpect(jsonPath("$[0].isLate").value(false))
                 .andExpect(jsonPath("$[1].nickname").value("철수"))
-                .andExpect(jsonPath("$[1].status").value("WAITING"));
+                .andExpect(jsonPath("$[1].status").value("WAITING"))
+                .andExpect(jsonPath("$[1].isLate").value(true));
 
         verify(assignmentQueryService).getAssignmentSummaries(memberId, processId);
     }

--- a/src/test/java/econovation/moongtaengi/study/application/AssignmentQueryServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/AssignmentQueryServiceTest.java
@@ -1,0 +1,99 @@
+package econovation.moongtaengi.study.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import econovation.moongtaengi.study.application.assignment.AssignmentQueryService;
+import econovation.moongtaengi.study.application.assignment.AssignmentSummary;
+import econovation.moongtaengi.study.domain.StudyErrorCode;
+import econovation.moongtaengi.study.domain.StudyException;
+import econovation.moongtaengi.study.domain.StudyMemberRepository;
+import econovation.moongtaengi.study.domain.assignment.AssignmentRepository;
+import econovation.moongtaengi.study.domain.process.StudyProcessRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AssignmentQueryServiceTest {
+
+    @InjectMocks
+    AssignmentQueryService assignmentQueryService;
+
+    @Mock
+    AssignmentRepository assignmentRepository;
+    @Mock
+    StudyProcessRepository processRepository;
+    @Mock
+    StudyMemberRepository studyMemberRepository;
+
+    @Test
+    @DisplayName("스터디 멤버가 존재하는 프로세스의 과제 목록을 조회하면, 과제 리스트를 반환한다.")
+    void 과제_목록_조회_성공() {
+        // given
+        Long memberId = 1L;
+        Long processId = 100L;
+        Long studyId = 10L;
+
+        given(processRepository.findStudyIdById(processId))
+                .willReturn(Optional.of(studyId));
+
+        given(studyMemberRepository.existsByStudyIdAndMemberId(studyId, memberId))
+                .willReturn(true);
+
+        List<AssignmentSummary> expectedResponse = List.of();
+        given(assignmentRepository.findSummaryByProcessIdAndStudyId(processId, studyId))
+                .willReturn(expectedResponse);
+
+        //when
+        List<AssignmentSummary> result = assignmentQueryService.getAssignmentSummaries(memberId,
+                processId);
+
+        //then
+        assertThat(result).isEqualTo(expectedResponse);
+        verify(assignmentRepository).findSummaryByProcessIdAndStudyId(processId, studyId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 프로세스 ID로 조회하면, PROCESS_NOT_FOUND 예외가 발생한다.")
+    void 과제_목록_조회_존재하지_않는_프로세스_실패() {
+        // given
+        given(processRepository.findStudyIdById(anyLong())).willReturn(Optional.empty());
+
+        //when&then
+        assertThatThrownBy(() ->
+                assignmentQueryService.getAssignmentSummaries(1L, 999L))
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.PROCESS_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("해당 스터디에 참여하지 않은 멤버가 조회하면, NOT_STUDY_MEMBER 예외가 발생한다.")
+    void 과제_목록_조회_스터디_멤버가_아님_실패() {
+        // given
+        Long memberId = 1L;
+        Long processId = 100L;
+        Long studyId = 10L;
+
+        given(processRepository.findStudyIdById(processId)).willReturn(Optional.of(studyId));
+
+        given(studyMemberRepository.existsByStudyIdAndMemberId(studyId, memberId))
+                .willReturn(false);
+
+        //when&then
+        assertThatThrownBy(() ->
+                assignmentQueryService.getAssignmentSummaries(memberId, processId))
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.NOT_STUDY_MEMBER);
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/application/CreateAssignmentServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/CreateAssignmentServiceTest.java
@@ -58,7 +58,7 @@ public class CreateAssignmentServiceTest {
                 .processId(DEFAULT_PROCESS_ID)
                 .requesterId(10L)
                 .assigneeId(DEFAULT_ASSIGNEE_ID)
-                .content(DEFAULT_CONTENT_VALUE)
+                .content(DEFAULT_CONTENT.getValue())
                 .deadline(requestDeadline)
                 .build();
 

--- a/src/test/java/econovation/moongtaengi/study/application/CreateSubmissionServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/CreateSubmissionServiceTest.java
@@ -54,7 +54,7 @@ public class CreateSubmissionServiceTest {
         ReflectionTestUtils.setField(savedSubmission, "id", 1L);
 
         given(assignmentInfoProvider.getAssignmentInfo(DEFAULT_ASSIGNMENT_ID))
-                .willReturn(new AssignmentInfo(DEFAULT_SUBMITTER_ID, DEFAULT_DEADLINE));
+                .willReturn(new AssignmentInfo(DEFAULT_SUBMITTER_ID, BASE_TIME));
 
         given(submissionRepository.save(any(Submission.class))).willReturn(savedSubmission);
 

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyFixture.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyFixture.java
@@ -1,0 +1,18 @@
+package econovation.moongtaengi.study.domain;
+
+import java.time.LocalDate;
+
+public class StudyFixture {
+
+    public static final LocalDate FIXED_DATE = LocalDate.of(2026, 1, 1);
+
+    public static Study aStudy(Long hostId) {
+        return new Study(
+                new StudyName("테스트 스터디"),
+                new StudyPeriod(FIXED_DATE.minusMonths(1), FIXED_DATE.plusMonths(1)),
+                new StudyTopic("테스트 주제"),
+                hostId,
+                new InviteCode("12345678")
+        );
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyProcessRepositoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyProcessRepositoryTest.java
@@ -6,10 +6,12 @@ import econovation.moongtaengi.study.domain.process.StudyProcess;
 import econovation.moongtaengi.study.domain.process.StudyProcessPeriodBound;
 import econovation.moongtaengi.study.domain.process.StudyProcessRepository;
 import java.time.LocalDate;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 @DataJpaTest
 public class StudyProcessRepositoryTest {
@@ -60,7 +62,24 @@ public class StudyProcessRepositoryTest {
         assertThat(bound.maxEndDate()).isNull();
     }
 
-    private void createAndSaveProcess(Long studyId, LocalDate startDate, LocalDate endDate) {
+    @Test
+    @DisplayName("Process ID로 Study ID를 찾아온다.")
+    void 프로세스_ID_스터디_ID_조회_성공() {
+        //given
+        Study study = StudyFixture.aStudy(1L);
+        studyRepository.save(study);
+
+        StudyProcess process = createAndSaveProcess(study.getId(), LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 10));
+
+        // when
+        Optional<Long> result = studyProcessRepository.findStudyIdById(process.getId());
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEqualTo(study.getId());
+    }
+
+    private StudyProcess createAndSaveProcess(Long studyId, LocalDate startDate, LocalDate endDate) {
         StudyProcess studyProcess = StudyProcess.create(
                 studyId,
                 1,
@@ -70,6 +89,6 @@ public class StudyProcessRepositoryTest {
                 "테스트 과제 설명"
         );
 
-        studyProcessRepository.save(studyProcess);
+        return studyProcessRepository.save(studyProcess);
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentFixture.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentFixture.java
@@ -1,34 +1,24 @@
 package econovation.moongtaengi.study.domain.assignment;
 
+import econovation.moongtaengi.study.domain.StudyFixture;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import org.springframework.test.util.ReflectionTestUtils;
 
 public class AssignmentFixture {
     public static final Long DEFAULT_PROCESS_ID = 1L;
     public static final Long DEFAULT_ASSIGNEE_ID = 1L;
-    public static final String DEFAULT_CONTENT_VALUE = "테스트 내용";
-    public static final AssignmentContent DEFAULT_CONTENT = new AssignmentContent(DEFAULT_CONTENT_VALUE);
+    public static final AssignmentContent DEFAULT_CONTENT = new AssignmentContent("테스트 과제");
+
+    public static final LocalDate BASE_DATE = StudyFixture.FIXED_DATE;
 
     public static Assignment.AssignmentBuilder anAssignment() {
-        LocalDate processStartDate = LocalDate.now();
-        LocalDate processEndDate = processStartDate.plusDays(14);
-        LocalDateTime requestDeadline = processStartDate.plusDays(7).atStartOfDay();
-
         return Assignment.builder()
                 .processId(DEFAULT_PROCESS_ID)
                 .assigneeId(DEFAULT_ASSIGNEE_ID)
                 .content(DEFAULT_CONTENT)
                 .deadline(AssignmentDeadline.create(
-                        requestDeadline,
-                        processStartDate,
-                        processEndDate
+                        BASE_DATE.plusDays(7).atStartOfDay(),
+                        BASE_DATE,
+                        BASE_DATE.plusDays(14)
                 ));
-    }
-
-    public static Assignment createSavedAssignment(Long id) {
-        Assignment assignment = anAssignment().build();
-        ReflectionTestUtils.setField(assignment, "id", id);
-        return assignment;
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepositoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepositoryTest.java
@@ -2,15 +2,33 @@ package econovation.moongtaengi.study.domain.assignment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import econovation.moongtaengi.member.domain.Member;
+import econovation.moongtaengi.member.domain.Nickname;
+import econovation.moongtaengi.study.application.assignment.AssignmentSummary;
+import econovation.moongtaengi.study.domain.InviteCode;
+import econovation.moongtaengi.study.domain.Study;
+import econovation.moongtaengi.study.domain.StudyName;
+import econovation.moongtaengi.study.domain.StudyPeriod;
+import econovation.moongtaengi.study.domain.StudyTopic;
+import econovation.moongtaengi.study.domain.submission.Submission;
+import econovation.moongtaengi.study.domain.submission.SubmissionAttachment;
+import econovation.moongtaengi.study.domain.submission.SubmissionContent;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 @DataJpaTest
 public class AssignmentRepositoryTest {
     @Autowired
     private AssignmentRepository assignmentRepository;
+    @Autowired
+    private TestEntityManager em;
+
 
     @Test
     @DisplayName("프로세스 ID와 과제 수행자 ID로 과제 존재 여부를 확인한다")
@@ -35,4 +53,86 @@ public class AssignmentRepositoryTest {
         assertThat(exists).isTrue();
         assertThat(notExists).isFalse();
     }
+
+    @Test
+    @DisplayName("스터디 멤버 기준으로 과제 목록 조회 (다른 스터디 멤버 제외)")
+    void 과제_목록_조회_성공() {
+        //given
+        Long processId = 100L;
+
+        Member host = createMember("방장");
+        Member guest = createMember("게스트");
+
+        Study myStudy = createStudy(host.getId());
+
+        myStudy.addGuest(guest.getId());
+        em.persistAndFlush(myStudy);
+
+        Assignment assignment1 = createAssignment(processId, host.getId());
+
+        createSubmission(assignment1, host);
+
+        assignment1.markAsSubmitted(false);
+        em.persistAndFlush(assignment1);
+
+        em.clear();
+
+        //when
+        List<AssignmentSummary> result =
+                assignmentRepository.findSummaryByProcessIdAndStudyId(processId, myStudy.getId());
+
+        //then
+        assertThat(result).hasSize(2);
+
+        AssignmentSummary dto1 = result.stream()
+                .filter(d -> d.nickname().equals("방장")) // ✨ 닉네임 일치!
+                .findFirst().get();
+        assertThat(dto1.status()).isEqualTo(AssignmentStatus.SUBMITTED);
+
+        AssignmentSummary dto2 = result.stream()
+                .filter(d -> d.nickname().equals("게스트")) // ✨ 닉네임 일치!
+                .findFirst().get();
+        assertThat(dto2.assignmentId()).isNull();
+    }
+
+
+    private Member createMember(String nickname) {
+        Member member = Member.createMember("kakao_" + nickname, new Nickname(nickname));
+        return em.persistAndFlush(member);
+    }
+
+    private Study createStudy(Long hostId) {
+        Study study = new Study(
+                new StudyName("테스트 스터디"),
+                new StudyPeriod(LocalDate.now(), LocalDate.now().plusDays(30)),
+                new StudyTopic("테스트 주제"),
+                hostId,
+                new InviteCode("12345678")
+        );
+        return em.persistAndFlush(study);
+    }
+
+    private Assignment createAssignment(Long processId, Long memberId) {
+        LocalDateTime now = LocalDateTime.now();
+        Assignment assignment = Assignment.create(
+                processId,
+                memberId,
+                new AssignmentContent("과제"),
+                AssignmentDeadline.create(now, now.toLocalDate(), now.plusDays(1).toLocalDate())
+        );
+        return em.persistAndFlush(assignment);
+    }
+
+    private void createSubmission(Assignment assignment, Member member) {
+        Submission submission = Submission.create(
+                assignment.getId(),
+                member.getId(),
+                new SubmissionContent("내용"),
+                LocalDateTime.now(),
+                assignment.getDeadline().getValue(),
+                List.of(new SubmissionAttachment("http://url.com"))
+        );
+        em.persistAndFlush(submission);
+    }
+
 }

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepositoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepositoryTest.java
@@ -89,6 +89,7 @@ public class AssignmentRepositoryTest {
 
         assertThat(dto1.status()).isEqualTo(AssignmentStatus.SUBMITTED);
         assertThat(dto1.submissionId()).isNotNull();
+        assertThat(dto1.memberId()).isEqualTo(host.getId());
         assertThat(dto1.fileUrl()).isEqualTo("http://url.com");
 
         AssignmentSummary dto2 = result.stream()

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepositoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepositoryTest.java
@@ -5,16 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import econovation.moongtaengi.member.domain.Member;
 import econovation.moongtaengi.member.domain.Nickname;
 import econovation.moongtaengi.study.application.assignment.AssignmentSummary;
-import econovation.moongtaengi.study.domain.InviteCode;
 import econovation.moongtaengi.study.domain.Study;
-import econovation.moongtaengi.study.domain.StudyName;
-import econovation.moongtaengi.study.domain.StudyPeriod;
-import econovation.moongtaengi.study.domain.StudyTopic;
-import econovation.moongtaengi.study.domain.submission.Submission;
+import econovation.moongtaengi.study.domain.StudyFixture;
 import econovation.moongtaengi.study.domain.submission.SubmissionAttachment;
-import econovation.moongtaengi.study.domain.submission.SubmissionContent;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import econovation.moongtaengi.study.domain.submission.SubmissionFixture;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -63,18 +57,23 @@ public class AssignmentRepositoryTest {
         Member host = createMember("방장");
         Member guest = createMember("게스트");
 
-        Study myStudy = createStudy(host.getId());
-
+        Study myStudy = em.persistAndFlush(StudyFixture.aStudy(host.getId()));
         myStudy.addGuest(guest.getId());
-        em.persistAndFlush(myStudy);
+        em.flush();
 
-        Assignment assignment1 = createAssignment(processId, host.getId());
+        Assignment assignment1 = em.persistAndFlush(AssignmentFixture.anAssignment()
+                .processId(processId)
+                .assigneeId(host.getId())
+                .build());
 
-        createSubmission(assignment1, host);
+        em.persistAndFlush(SubmissionFixture.aSubmission()
+                .assignmentId(assignment1.getId())
+                .submitterId(host.getId())
+                .attachments(List.of(new SubmissionAttachment("http://url.com")))
+                .build());
 
         assignment1.markAsSubmitted(false);
-        em.persistAndFlush(assignment1);
-
+        em.flush();
         em.clear();
 
         //when
@@ -85,13 +84,17 @@ public class AssignmentRepositoryTest {
         assertThat(result).hasSize(2);
 
         AssignmentSummary dto1 = result.stream()
-                .filter(d -> d.nickname().equals("방장")) // ✨ 닉네임 일치!
+                .filter(d -> d.nickname().equals("방장"))
                 .findFirst().get();
+
         assertThat(dto1.status()).isEqualTo(AssignmentStatus.SUBMITTED);
+        assertThat(dto1.submissionId()).isNotNull();
+        assertThat(dto1.fileUrl()).isEqualTo("http://url.com");
 
         AssignmentSummary dto2 = result.stream()
-                .filter(d -> d.nickname().equals("게스트")) // ✨ 닉네임 일치!
+                .filter(d -> d.nickname().equals("게스트"))
                 .findFirst().get();
+
         assertThat(dto2.assignmentId()).isNull();
     }
 
@@ -99,40 +102,6 @@ public class AssignmentRepositoryTest {
     private Member createMember(String nickname) {
         Member member = Member.createMember("kakao_" + nickname, new Nickname(nickname));
         return em.persistAndFlush(member);
-    }
-
-    private Study createStudy(Long hostId) {
-        Study study = new Study(
-                new StudyName("테스트 스터디"),
-                new StudyPeriod(LocalDate.now(), LocalDate.now().plusDays(30)),
-                new StudyTopic("테스트 주제"),
-                hostId,
-                new InviteCode("12345678")
-        );
-        return em.persistAndFlush(study);
-    }
-
-    private Assignment createAssignment(Long processId, Long memberId) {
-        LocalDateTime now = LocalDateTime.now();
-        Assignment assignment = Assignment.create(
-                processId,
-                memberId,
-                new AssignmentContent("과제"),
-                AssignmentDeadline.create(now, now.toLocalDate(), now.plusDays(1).toLocalDate())
-        );
-        return em.persistAndFlush(assignment);
-    }
-
-    private void createSubmission(Assignment assignment, Member member) {
-        Submission submission = Submission.create(
-                assignment.getId(),
-                member.getId(),
-                new SubmissionContent("내용"),
-                LocalDateTime.now(),
-                assignment.getDeadline().getValue(),
-                List.of(new SubmissionAttachment("http://url.com"))
-        );
-        em.persistAndFlush(submission);
     }
 
 }

--- a/src/test/java/econovation/moongtaengi/study/domain/submission/SubmissionFixture.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/submission/SubmissionFixture.java
@@ -1,5 +1,6 @@
 package econovation.moongtaengi.study.domain.submission;
 
+import econovation.moongtaengi.study.domain.StudyFixture;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 
@@ -7,9 +8,8 @@ public class SubmissionFixture {
 
     public static final Long DEFAULT_ASSIGNMENT_ID = 1L;
     public static final Long DEFAULT_SUBMITTER_ID = 1L;
-    public static final SubmissionContent DEFAULT_CONTENT = new SubmissionContent("테스트 제출 내용");
-    public static final LocalDateTime DEFAULT_CURRENT_TIME = LocalDateTime.of(2026, 1, 1, 0, 0);
-    public static final LocalDateTime DEFAULT_DEADLINE = DEFAULT_CURRENT_TIME.plusDays(5);
+    public static final SubmissionContent DEFAULT_CONTENT = new SubmissionContent("제출 완료");
+    public static final LocalDateTime BASE_TIME = StudyFixture.FIXED_DATE.atStartOfDay();
 
     public static Submission.SubmissionBuilder aSubmission() {
         return Submission.builder()
@@ -17,7 +17,7 @@ public class SubmissionFixture {
                 .submitterId(DEFAULT_SUBMITTER_ID)
                 .content(DEFAULT_CONTENT)
                 .attachments(new ArrayList<>())
-                .currentDateTime(DEFAULT_CURRENT_TIME)
-                .assignmentDeadline(DEFAULT_DEADLINE);
+                .currentDateTime(BASE_TIME.plusDays(1))
+                .assignmentDeadline(BASE_TIME.plusDays(7));
     }
 }


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
**설계 의도**
1. API 엔드포인트 평탄화 (GET /api/assignments?processId={id})
- 기존의 계층형 구조(/studies/{studyId}/processes/{processId}/...)는 프론트엔드에서 불필요하게 상위 리소스의 ID를 관리해야 함.
- 이를 해결하기 위해 유니크한 processId만으로 조회가 가능하도록 설계를 변경

2. 백엔드 역추적 검증 로직 도입
- 만약 studyId 와 processId 까지 파라미터로 받을 경우 StudyMember 를 통해 권한 검증 통과 -> processId 를 아무거나 조회 가능
- 따라서 processId → studyId 조회 → StudyMember 권한 검증 순서로 이어지는 검증을 수행
- 이 과정에서 성능 저하를 최소화하기 위해 select studyId , exists 쿼리를 활용.

3. StudyMember 드라이빙 테이블 선정
- 과제를 제출하지 않은 멤버나, 아직 과제가 할당되지 않은 멤버의 현황도 모두 보여주기 위해 Assignment가 아닌 StudyMember를 기준으로 LEFT JOIN을 수행.
---
Domain & Repository

- AssignmentRepository
    - StudyMember를 드라이빙 테이블로 하여 과제, 제출, 첨부파일을 LEFT JOIN하는 JPQL 구현

- StudyProcessRepository
    - processId로 studyId만 가볍게 조회하는 Projection 쿼리 추가

Application

- AssignmentQueryService
  - studyId 역추적 및 멤버 권한 검증 로직 구현
  - 검증 통과 시 Repository를 통해 List<AssignmentSummary> 반환


Presentation 

- AssignmentController
  - @LoginMemberId와 @RequestParam을 활용한 API 인터페이스 정의
  - AssignmentSummary DTO에 memberId(할당용), isLate(지각 여부) 필드 포함

Test & Refactor

- Fixture 개선
  - 모든 테스트 픽스쳐의 기준 시간을 2026-01-01로 고정하여 테스트 안정성 확보

- Repository(Data), Service(Flow), Controller(Spec) 계층별 테스트 작성 완료
### 🧪 테스트 결과
- [x] 테스트 코드 모두 완료하였습니다! 
- [x] 포스트맨 이용 테스트
<img width="524" height="674" alt="image" src="https://github.com/user-attachments/assets/f6122d0e-9600-4e4a-bf68-fb8305027ef7" />
<img width="524" height="441" alt="image" src="https://github.com/user-attachments/assets/cd4e3a30-8bf5-4107-a8f6-adfeb45aaa37" />
 
### 👿 트러블 슈팅
**1. JPQL Projection Type Mismatch 해결**
- `ProcessRepository`에서 ID 조회 시 `QueryTypeMismatchException` 발생.
- 원인: JPQL이 엔티티 전체(`p`)를 반환하려 시도.
- 해결: `SELECT p.studyId`로 명시적 프로젝션을 적용하여 해결 및 메모리 절약.

**2. ID 참조 엔티티 간의 Join 구현**
- `StudyMember`와 `Assignment`는 ID 참조 관계(별도 애그리게이트)여서 JPA 네이밍 쿼리로 조인이 불가능.
- JPQL의 `ON` 절(`JOIN Assignment a ON a.assigneeId = m.id`)을 사용하여 도메인 분리를 유지하면서 조회 성능 확보.
### 💬 코멘트
전에 첨부파일이 nullable이 되는 게 싫어서 List로 구현했었는데 이 부분이 여러 개의 튜플을 반환하는 가능성이 있을 수 있을 것 같습니다. 지금은 비즈니스 요구사항이 첨부파일이 1개라서 큰 상관은 없을 것 같습니다! 나중에 첨부파일이 늘어나거나 그랬을 때 여러 방안 생각해보도록 하겠습니다! 



