### PR TITLE
feat: 과제 단건 상세 조회 기능 및 API 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/api/AssignmentController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/AssignmentController.java
@@ -2,6 +2,7 @@ package econovation.moongtaengi.study.api;
 
 import econovation.moongtaengi.global.annotation.LoginMemberId;
 import econovation.moongtaengi.study.api.dto.AssignmentCreateRequest;
+import econovation.moongtaengi.study.application.assignment.AssignmentDetail;
 import econovation.moongtaengi.study.application.assignment.AssignmentQueryService;
 import econovation.moongtaengi.study.application.assignment.AssignmentSummary;
 import econovation.moongtaengi.study.application.assignment.CreateAssignmentCommand;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -53,6 +55,16 @@ public class AssignmentController {
             @RequestParam Long processId
     ) {
         List<AssignmentSummary> response = assignmentQueryService.getAssignmentSummaries(memberId, processId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{assignmentId}")
+    public ResponseEntity<AssignmentDetail> getAssignmentDetail(
+            @LoginMemberId Long memberId,
+            @PathVariable Long assignmentId
+    ) {
+        AssignmentDetail response = assignmentQueryService.getAssignmentDetail(memberId, assignmentId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentDetail.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentDetail.java
@@ -1,0 +1,29 @@
+package econovation.moongtaengi.study.application.assignment;
+
+import econovation.moongtaengi.member.domain.Title;
+import econovation.moongtaengi.study.domain.assignment.AssignmentDetailRaw;
+import java.time.LocalDateTime;
+
+public record AssignmentDetail(
+        Long studyId,
+        String studyName,
+        String assignmentContent,
+        String nickname,
+        String memberTitle,
+        Long submissionId,
+        LocalDateTime submitTime,
+        boolean isOwner
+) {
+    public static AssignmentDetail of(Long memberId, AssignmentDetailRaw raw) {
+        return new AssignmentDetail(
+                raw.studyId(),
+                raw.studyName(),
+                raw.assignmentContent(),
+                raw.nickname(),
+                Title.fromExperience(raw.totalExperience()).getDisplayName(),
+                raw.submissionId(),
+                raw.submitTime(),
+                raw.assigneeId().equals(memberId)
+        );
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentQueryService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentQueryService.java
@@ -3,8 +3,11 @@ package econovation.moongtaengi.study.application.assignment;
 import econovation.moongtaengi.study.domain.StudyErrorCode;
 import econovation.moongtaengi.study.domain.StudyException;
 import econovation.moongtaengi.study.domain.StudyMemberRepository;
+import econovation.moongtaengi.study.domain.assignment.AssignmentDetailRaw;
+import econovation.moongtaengi.study.domain.assignment.AssignmentException;
 import econovation.moongtaengi.study.domain.assignment.AssignmentRepository;
 import econovation.moongtaengi.study.domain.process.StudyProcessRepository;
+import econovation.moongtaengi.study.domain.assignment.AssignmentErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,6 +31,18 @@ public class AssignmentQueryService {
         }
 
         return assignmentRepository.findSummaryByProcessIdAndStudyId(processId, studyId);
+    }
+
+    public AssignmentDetail getAssignmentDetail(Long memberId, Long assignmentId) {
+        AssignmentDetailRaw raw = assignmentRepository.findDetailRawById(assignmentId)
+                .orElseThrow(() -> new AssignmentException(AssignmentErrorCode.ASSIGNMENT_NOT_FOUND));
+
+        boolean isMember = studyMemberRepository.existsByStudyIdAndMemberId(raw.studyId(), memberId);
+        if (!isMember) {
+            throw new StudyException(StudyErrorCode.NOT_STUDY_MEMBER);
+        }
+
+        return AssignmentDetail.of(memberId, raw);
     }
 
 }

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentDetailRaw.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentDetailRaw.java
@@ -3,6 +3,7 @@ package econovation.moongtaengi.study.domain.assignment;
 import java.time.LocalDateTime;
 
 public record AssignmentDetailRaw(
+        Long studyId,
         String studyName,
         String assignmentContent,
         String nickname,

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentDetailRaw.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentDetailRaw.java
@@ -1,0 +1,14 @@
+package econovation.moongtaengi.study.domain.assignment;
+
+import java.time.LocalDateTime;
+
+public record AssignmentDetailRaw(
+        String studyName,
+        String assignmentContent,
+        String nickname,
+        Long assigneeId,
+        int totalExperience,
+        Long submissionId,
+        LocalDateTime submitTime
+) {
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentErrorCode.java
@@ -14,7 +14,9 @@ public enum AssignmentErrorCode implements ErrorCode {
 
     ASSIGNMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "AS_003", "해당 프로세스에 이미 할당된 과제가 존재합니다."),
 
-    INVALID_PROCESS_ID(HttpStatus.BAD_REQUEST, "AS_004","유효하지 않은 프로세스 ID 입니다.");
+    INVALID_PROCESS_ID(HttpStatus.BAD_REQUEST, "AS_004","유효하지 않은 프로세스 ID 입니다."),
+
+    ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "AS_005", "존재하지 않는 과제입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepository.java
@@ -49,6 +49,7 @@ public interface AssignmentRepository extends JpaRepository<Assignment, Long> {
 
     @Query("""
         SELECT new econovation.moongtaengi.study.domain.assignment.AssignmentDetailRaw(
+            s.id,
             s.name.value,
             a.content.value,
             m.nickname.value,

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepository.java
@@ -2,6 +2,7 @@ package econovation.moongtaengi.study.domain.assignment;
 
 import econovation.moongtaengi.study.application.assignment.AssignmentSummary;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -45,4 +46,23 @@ public interface AssignmentRepository extends JpaRepository<Assignment, Long> {
      */
     @Query("SELECT a FROM Assignment a WHERE a.processId IN :processIds AND a.status = :status")
     List<Assignment> findByProcessIdInAndStatus(@Param("processIds") List<Long> processIds, @Param("status") AssignmentStatus status);
+
+    @Query("""
+        SELECT new econovation.moongtaengi.study.domain.assignment.AssignmentDetailRaw(
+            s.name.value,
+            a.content.value,
+            m.nickname.value,
+            a.assigneeId,
+            m.totalExperience,
+            sub.id,
+            sub.createdAt
+        )
+        FROM Assignment a
+        JOIN StudyProcess p ON a.processId = p.id
+        JOIN Study s ON p.studyId = s.id
+        JOIN Member m ON m.id = a.assigneeId
+        LEFT JOIN Submission sub ON sub.assignmentId = a.id AND sub.submitterId = m.id
+        WHERE a.id = :assignmentId
+    """)
+    Optional<AssignmentDetailRaw> findDetailRawById(@Param("assignmentId") Long assignmentId);
 }

--- a/src/test/java/econovation/moongtaengi/study/api/AssignmentControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/AssignmentControllerTest.java
@@ -3,6 +3,7 @@ package econovation.moongtaengi.study.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -10,6 +11,7 @@ import econovation.moongtaengi.global.config.WebConfig;
 import econovation.moongtaengi.global.security.CustomAuthentication;
 import econovation.moongtaengi.global.security.LoginMemberIdArgumentResolver;
 import econovation.moongtaengi.study.api.dto.AssignmentCreateRequest;
+import econovation.moongtaengi.study.application.assignment.AssignmentDetail;
 import econovation.moongtaengi.study.application.assignment.AssignmentQueryService;
 import econovation.moongtaengi.study.application.assignment.AssignmentSummary;
 import econovation.moongtaengi.study.application.assignment.CreateAssignmentCommand;
@@ -23,6 +25,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import econovation.moongtaengi.study.domain.StudyErrorCode;
+import econovation.moongtaengi.study.domain.StudyException;
+import econovation.moongtaengi.study.domain.assignment.AssignmentErrorCode;
+import econovation.moongtaengi.study.domain.assignment.AssignmentException;
 import econovation.moongtaengi.study.domain.assignment.AssignmentStatus;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -207,5 +213,72 @@ public class AssignmentControllerTest {
                 .andExpect(jsonPath("$[1].isLate").value(true));
 
         verify(assignmentQueryService).getAssignmentSummaries(memberId, processId);
+    }
+
+    @Test
+    @DisplayName("과제 상세 조회 성공 시 200 OK와 함께 상세 정보를 반환한다")
+    void 과제_상세_조회_성공() throws Exception {
+        //given
+        Long loginMemberId = 1L;
+        Long assignmentId = 10L;
+
+        AssignmentDetail response = new AssignmentDetail(
+                100L,
+                "테스트 스터디",
+                "테스트 과제",
+                "지환",
+                "비기너",
+                null,
+                null,
+                true
+        );
+
+        given(assignmentQueryService.getAssignmentDetail(loginMemberId, assignmentId))
+                .willReturn(response);
+
+        //when&then
+        mvc.perform(get("/api/assignments/{assignmentId}", assignmentId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.studyId").value(100L))
+                .andExpect(jsonPath("$.studyName").value("테스트 스터디"))
+                .andExpect(jsonPath("$.assignmentContent").value("테스트 과제"))
+                .andExpect(jsonPath("$.nickname").value("지환"))
+                .andExpect(jsonPath("$.memberTitle").value("비기너"))
+                .andExpect(jsonPath("$.isOwner").value(true))
+                .andExpect(jsonPath("$.submissionId").isEmpty());
+
+        verify(assignmentQueryService).getAssignmentDetail(loginMemberId, assignmentId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 과제 조회 시 404 Not Found를 반환한다")
+    void 과제_상세_조회_실패_미존재() throws Exception {
+        //given
+        Long invalidId = 999L;
+
+        given(assignmentQueryService.getAssignmentDetail(any(), eq(invalidId)))
+                .willThrow(new AssignmentException(AssignmentErrorCode.ASSIGNMENT_NOT_FOUND));
+
+        //when&then
+        mvc.perform(get("/api/assignments/{assignmentId}", invalidId))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("스터디 멤버가 아닌 경우 403 Forbidden을 반환한다")
+    void 과제_상세_조회_실패_권한없음() throws Exception {
+        //given
+        Long assignmentId = 10L;
+
+        given(assignmentQueryService.getAssignmentDetail(any(), eq(assignmentId)))
+                .willThrow(new StudyException(StudyErrorCode.NOT_STUDY_MEMBER));
+
+        //when&then
+        mvc.perform(get("/api/assignments/{assignmentId}", assignmentId))
+                .andDo(print())
+                .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/application/AssignmentQueryServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/AssignmentQueryServiceTest.java
@@ -2,15 +2,21 @@ package econovation.moongtaengi.study.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import econovation.moongtaengi.member.domain.Title;
+import econovation.moongtaengi.study.application.assignment.AssignmentDetail;
 import econovation.moongtaengi.study.application.assignment.AssignmentQueryService;
 import econovation.moongtaengi.study.application.assignment.AssignmentSummary;
 import econovation.moongtaengi.study.domain.StudyErrorCode;
 import econovation.moongtaengi.study.domain.StudyException;
 import econovation.moongtaengi.study.domain.StudyMemberRepository;
+import econovation.moongtaengi.study.domain.assignment.AssignmentDetailRaw;
+import econovation.moongtaengi.study.domain.assignment.AssignmentErrorCode;
+import econovation.moongtaengi.study.domain.assignment.AssignmentException;
 import econovation.moongtaengi.study.domain.assignment.AssignmentRepository;
 import econovation.moongtaengi.study.domain.process.StudyProcessRepository;
 import java.util.List;
@@ -96,4 +102,127 @@ class AssignmentQueryServiceTest {
                 .extracting("errorCode")
                 .isEqualTo(StudyErrorCode.NOT_STUDY_MEMBER);
     }
+
+    @Test
+    @DisplayName("과제 상세 조회 성공 및 칭호 변환과 본인 여부가 정확해야 한다")
+    void 과제_상세_조회_성공() {
+        //given
+        Long loginMemberId = 1L;
+        Long assignmentId = 10L;
+        Long assigneeId = 1L;
+        Long studyId = 100L;
+        int experience = 100;
+
+        AssignmentDetailRaw raw = new AssignmentDetailRaw(
+                studyId,
+                "테스트 스터디",
+                "테스트 과제",
+                "지환",
+                assigneeId,
+                experience,
+                null,
+                null
+        );
+
+        given(assignmentRepository.findDetailRawById(assignmentId))
+                .willReturn(Optional.of(raw));
+
+        given(studyMemberRepository.existsByStudyIdAndMemberId(studyId, loginMemberId))
+                .willReturn(true);
+
+        // when
+        AssignmentDetail result = assignmentQueryService.getAssignmentDetail(loginMemberId, assignmentId);
+
+        // then
+        assertThat(result.memberTitle()).isEqualTo(Title.fromExperience(experience).getDisplayName());
+        assertThat(result.isOwner()).isTrue();
+        assertThat(result.studyName()).isEqualTo("테스트 스터디");
+        assertThat(result.assignmentContent()).isEqualTo("테스트 과제");
+    }
+
+    @Test
+    @DisplayName("타인의 과제를 조회하면 isOwner는 false여야 한다")
+    void 타인의_과제는_isOwner_false() {
+        //given
+        Long loginMemberId = 999L;
+        Long assignmentId = 10L;
+        Long assigneeId = 1L;
+        Long studyId = 100L;
+
+        AssignmentDetailRaw raw = new AssignmentDetailRaw(
+                studyId,
+                "스터디",
+                "내용",
+                "닉네임",
+                assigneeId,
+                0,
+                null,
+                null
+        );
+
+        given(assignmentRepository.findDetailRawById(assignmentId))
+                .willReturn(Optional.of(raw));
+
+        given(studyMemberRepository.existsByStudyIdAndMemberId(studyId, loginMemberId))
+                .willReturn(true);
+
+        //when
+        AssignmentDetail result = assignmentQueryService.getAssignmentDetail(loginMemberId, assignmentId);
+
+        //then
+        assertThat(result.isOwner()).isFalse();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 과제 조회 시 예외가 발생해야 한다")
+    void 존재하지_않는_과제_조회_실패() {
+        // given
+        given(assignmentRepository.findDetailRawById(any()))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                assignmentQueryService.getAssignmentDetail(1L, 999L)
+        )
+                .isInstanceOf(AssignmentException.class)
+                .extracting("errorCode")
+                .isEqualTo(AssignmentErrorCode.ASSIGNMENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("스터디의 멤버가 아닐 시 과제 조회를 할 경우 예외가 발생한다.")
+    void 스터디_멤버_아닐_시_단건_조회_실패() {
+        //given
+        Long studyId = 1L;
+        Long loginMemberId = 999L;
+        Long assignmentId = 10L;
+        Long assigneeId = 1L;
+
+        AssignmentDetailRaw raw = new AssignmentDetailRaw(
+                studyId,
+                "테스트 스터디",
+                "테스트 내용",
+                "지환",
+                assigneeId,
+                0,
+                null,
+                null
+        );
+
+        given(assignmentRepository.findDetailRawById(assignmentId))
+                .willReturn(Optional.of(raw));
+        given(studyMemberRepository.existsByStudyIdAndMemberId(studyId, loginMemberId))
+                .willReturn(false);
+
+        //when&then
+        assertThatThrownBy(() ->
+                assignmentQueryService.getAssignmentDetail(loginMemberId, assignmentId)
+        )
+                .isInstanceOf(StudyException.class)
+                .extracting("errorCode")
+                .isEqualTo(StudyErrorCode.NOT_STUDY_MEMBER);
+
+
+    }
+
 }

--- a/src/test/java/econovation/moongtaengi/study/domain/StudyProcessFixture.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/StudyProcessFixture.java
@@ -1,0 +1,23 @@
+package econovation.moongtaengi.study.domain;
+
+import econovation.moongtaengi.study.domain.process.StudyProcess;
+import java.time.LocalDate;
+
+public class StudyProcessFixture {
+
+    public static final Integer DEFAULT_PROCESS_ORDER = 1;
+    public static final String DEFAULT_TITLE = "테스트 프로세스";
+    public static final LocalDate BASE_DATE = StudyFixture.FIXED_DATE;
+    public static final String DEFAULT_ASSIGNMENT_DESCRIPTION = "테스트 과제";
+
+    public static StudyProcess aStudyProcess(Long studyId) {
+        return StudyProcess.create(
+                studyId,
+                DEFAULT_PROCESS_ORDER,
+                DEFAULT_TITLE,
+                BASE_DATE,
+                BASE_DATE.plusDays(14),
+                DEFAULT_ASSIGNMENT_DESCRIPTION
+        );
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepositoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepositoryTest.java
@@ -7,6 +7,9 @@ import econovation.moongtaengi.member.domain.Nickname;
 import econovation.moongtaengi.study.application.assignment.AssignmentSummary;
 import econovation.moongtaengi.study.domain.Study;
 import econovation.moongtaengi.study.domain.StudyFixture;
+import econovation.moongtaengi.study.domain.StudyProcessFixture;
+import econovation.moongtaengi.study.domain.process.StudyProcess;
+import econovation.moongtaengi.study.domain.submission.Submission;
 import econovation.moongtaengi.study.domain.submission.SubmissionAttachment;
 import econovation.moongtaengi.study.domain.submission.SubmissionFixture;
 import java.util.List;
@@ -97,6 +100,72 @@ public class AssignmentRepositoryTest {
                 .findFirst().get();
 
         assertThat(dto2.assignmentId()).isNull();
+    }
+
+    @Test
+    @DisplayName("과제 상세 정보 조회 시 Member의 경험치와 Submission 정보(LEFT JOIN)가 포함되어야 한다")
+    void 과제_상세_조회_제출물_정보_성공() {
+        //given
+        Member member = createMember("지환");
+        member.addExperience(500);
+        em.persistAndFlush(member);
+
+        Study study = StudyFixture.aStudy(member.getId());
+        em.persistAndFlush(study);
+
+        StudyProcess process = StudyProcessFixture.aStudyProcess(study.getId());
+        em.persistAndFlush(process);
+
+        Assignment assignment = AssignmentFixture.anAssignment()
+                .processId(process.getId())
+                .assigneeId(member.getId())
+                .build();
+        em.persistAndFlush(assignment);
+
+        Submission submission = SubmissionFixture.aSubmission()
+                .assignmentId(assignment.getId())
+                .submitterId(member.getId())
+                .build();
+        em.persistAndFlush(submission);
+
+        //when
+        AssignmentDetailRaw result = assignmentRepository.findDetailRawById(assignment.getId())
+                .orElseThrow();
+
+        //then
+        assertThat(result.studyName()).isEqualTo(study.getName().getValue());
+        assertThat(result.assignmentContent()).isEqualTo("테스트 과제");
+        assertThat(result.nickname()).isEqualTo("지환");
+        assertThat(result.totalExperience()).isEqualTo(500);
+        assertThat(result.submissionId()).isEqualTo(submission.getId());
+        assertThat(result.assigneeId()).isEqualTo(member.getId());
+    }
+
+    @Test
+    @DisplayName("제출하지 않은 과제를 조회하면 submission 관련 필드는 null이어야 한다")
+    void 과제_상세_조회_제출물_없음_성공() {
+        Member member = createMember("철수");
+        em.persistAndFlush(member);
+
+        Study study = StudyFixture.aStudy(member.getId());
+        em.persistAndFlush(study);
+
+        StudyProcess process = StudyProcessFixture.aStudyProcess(study.getId());
+        em.persistAndFlush(process);
+
+        Assignment assignment = AssignmentFixture.anAssignment()
+                .processId(process.getId())
+                .build();
+        em.persistAndFlush(assignment);
+
+        //when
+        AssignmentDetailRaw result = assignmentRepository.findDetailRawById(assignment.getId())
+                .orElseThrow();
+
+        //then
+        assertThat(result.submissionId()).isNull();
+        assertThat(result.submitTime()).isNull();
+        assertThat(result.assignmentContent()).isEqualTo("테스트 과제");
     }
 
 

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepositoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepositoryTest.java
@@ -104,5 +104,4 @@ public class AssignmentRepositoryTest {
         Member member = Member.createMember("kakao_" + nickname, new Nickname(nickname));
         return em.persistAndFlush(member);
     }
-
 }


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용

**Repository** 

- 과제 단건 상세 조회 쿼리 구현 (findDetailRawById)
  - Assignment, Process, Study, Member 테이블을 조인하여 필요한 데이터(스터디명, 닉네임, 경험치 등)를 한 번에 조회하도록 최적화
  - Submission 테이블에 LEFT JOIN을 적용하여 과제를 아직 제출하지 않은 상태(미제출)의 데이터도 정상적으로 조회되도록 보장
  - 권한 검증 효율화를 위해 조회 시점부터 studyId를 Projection(AssignmentDetailRaw)에 포함.

**Service (Business Logic)**

- 과제 상세 조회 로직 구현 (AssignmentQueryService)
  - 조회된 Raw 데이터의 studyId를 활용하여, 별도의 추가 쿼리 없이 스터디 멤버십(권한) 검증을 수행
  - 존재하지 않는 과제 조회 시 ASSIGNMENT_NOT_FOUND, 권한이 없는 경우 NOT_STUDY_MEMBER 예외가 발생하도록 처리

- **응답 DTO 변환 로직 캡슐화**
  - AssignmentDetail DTO의 팩토리 메서드(of) 내부에 경험치 기반 칭호 변환(Title) 및 조회 당사자의 본인 여부(isOwner) 확인 로직을 응집

**Controller & DTO**

- API 엔드포인트 추가
  - GET /api/assignments/{assignmentId} (상세 조회)

- DTO 정의
  - AssignmentDetailRaw: Repository Projection용 Raw Data
  - AssignmentDetail: 클라이언트 응답용 상세 정보

**Test**
- 계층별 테스트 코드 작성
  - Repository: TestEntityManager를 활용한 연관관계 데이터 셋업 및 JPQL 동작 검증
  - Service: Mock 객체를 활용한 정상 조회 및 예외 케이스(미존재, 권한 없음) 검증
  - Controller: WebMvcTest를 통해 HTTP 상태 코드(200, 403, 404) 및 응답 JSON 필드 매핑 검증
### 🧪 테스트 결과
- [x] 테스트 코드 모두 통과하였습니다! 
### 👿 트러블 슈팅
**권한 검증을 위한 역추적 비용 최적화**

- 문제 
  - API가 `/assignments/{id}` (Flat URL) 구조라서 요청 시 `studyId`를 알 수 없음.
  - 권한 검증(`StudyMember` 확인)을 하려면 `Assignment` -> `Process` -> `Study`를 거쳐 `studyId`를 찾아내는 추가 쿼리(혹은 다중 조인) 필연적으로 발생함.

- 해결
  - 화면 요구사항에 '스터디 이름'이 필요하다는 점을 포착.
  - 어차피 `Study` 테이블을 조인해야 하므로, 이때 `studyId`도 같이 Projection(DTO)에 태워서 조회.
  - 결과적으로 검증을 위한 추가 쿼리 0회로 성능 저하 없이 권한 체크 구현.

**DB 정규화 vs 반정규화 설계 고민**

- 문제
  - `Assignment` 테이블이 `studyId`를 직접 갖지 않는 구조.
  - 이로 인해 단순 조회나 검증 시 `Process` 테이블을 항상 거쳐야 하는 구조적 불편함 발생.
  - 반정규화(`study_id` 컬럼 추가)를 해야 하나?에 대한 고민.

- 해결
  - 현재 트래픽 규모와 데이터 무결성을 최우선으로 하여 정규화 구조 유지 결정.
  - 대신 Service 계층에서 조회 최적화를 수행하고, 추후 성능 병목 발생 시 반정규화 설계 전략 의논 필요.

** CQRS 조회 모델에서의 에러 코드 처리**

- 문제
  - `AssignmentQueryService`에서 권한 검증 실패 시 `AssignmentErrorCode`를 써야 하는지, `StudyErrorCode`를 써야 하는지 고민.
  - 도메인 경계를 지키려다 보면 에러 코드를 억지로 래핑해야 하는 비효율 발생.

- 해결 
  - CQRS의 Query(조회) 모델은 UI를 위해 여러 도메인을 참조하는 역할임을 인지.
  - 에러의 출처인 `StudyErrorCode.NOT_STUDY_MEMBER`를 직접 사용하여, 클라이언트가 일관된 에러 처리를 할 수 있도록 지원.
### 💬 코멘트
상세 조회 시 권한 검증을 위해 Assignment -> Process -> Study를 거쳐 studyId를 획득하는 비용을 최소화하려고, 상세 조회 쿼리 실행 시 studyId를 함께 가져오도록 설계했습니다. 추후 성능 이슈 발생 시 비정규화(Assignment에 studyId 컬럼 추가)를 검토해보면 좋을 것 같습니다! 


