### PR TITLE
feat: 제출물 댓글 도메인 구현 및 생성 API 추가

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/api/CommentController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/CommentController.java
@@ -1,0 +1,35 @@
+package econovation.moongtaengi.study.api;
+
+import econovation.moongtaengi.global.annotation.LoginMemberId;
+import econovation.moongtaengi.study.api.dto.CommentCreateRequest;
+import econovation.moongtaengi.study.application.comment.CreateCommentCommand;
+import econovation.moongtaengi.study.application.comment.CreateCommentService;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class CommentController {
+
+    private final CreateCommentService createCommentService;
+
+    @PostMapping("/submissions/{submissionId}/comments")
+    public ResponseEntity<Void> createComment(
+            @LoginMemberId Long memberId,
+            @PathVariable Long submissionId,
+            @RequestBody CommentCreateRequest request
+    ) {
+        CreateCommentCommand command = request.toCommand(memberId, submissionId);
+
+        Long commentId = createCommentService.createComment(command);
+
+        return ResponseEntity.created(URI.create("/api/comments/" + commentId)).build();
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/api/dto/CommentCreateRequest.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/CommentCreateRequest.java
@@ -1,0 +1,15 @@
+package econovation.moongtaengi.study.api.dto;
+
+import econovation.moongtaengi.study.application.comment.CreateCommentCommand;
+
+public record CommentCreateRequest(
+        String content
+) {
+    public CreateCommentCommand toCommand(Long memberId, Long submissionId) {
+        return new CreateCommentCommand(
+                memberId,
+                submissionId,
+                content
+        );
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/application/comment/CreateCommentCommand.java
+++ b/src/main/java/econovation/moongtaengi/study/application/comment/CreateCommentCommand.java
@@ -1,0 +1,8 @@
+package econovation.moongtaengi.study.application.comment;
+
+public record CreateCommentCommand(
+        Long memberId,
+        Long submissionId,
+        String content
+) {
+}

--- a/src/main/java/econovation/moongtaengi/study/application/comment/CreateCommentService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/comment/CreateCommentService.java
@@ -1,0 +1,33 @@
+package econovation.moongtaengi.study.application.comment;
+
+import econovation.moongtaengi.study.domain.comment.Comment;
+import econovation.moongtaengi.study.domain.comment.CommentContent;
+import econovation.moongtaengi.study.domain.comment.CommentMemberValidator;
+import econovation.moongtaengi.study.domain.comment.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CreateCommentService {
+
+    private final CommentRepository commentRepository;
+    private final CommentMemberValidator commentMemberValidator;
+
+    public Long createComment(CreateCommentCommand command) {
+        commentMemberValidator.validate(command.memberId(), command.submissionId());
+
+        Comment comment = Comment.create(
+                command.submissionId(),
+                command.memberId(),
+                new CommentContent(command.content())
+        );
+
+        commentRepository.save(comment);
+
+        return comment.getId();
+    }
+
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/comment/Comment.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/comment/Comment.java
@@ -30,12 +30,30 @@ public class Comment extends BaseEntity {
     }
 
     public static Comment create(Long submissionId, Long memberId, CommentContent content) {
-        validate(submissionId, memberId, content);
+        validateCreation(submissionId, memberId, content);
         return new Comment(submissionId, memberId, content);
     }
 
-    private static void validate(Long submissionId, Long memberId, CommentContent content) {
+    public void updateContent(Long requestMemberId, CommentContent content) {
+        validateOwner(requestMemberId);
+        validateContent(content);
+        this.content = content;
+    }
+
+    private static void validateCreation(Long submissionId, Long memberId, CommentContent content) {
         if (submissionId == null || memberId == null || content == null) {
+            throw new CommentException(CommentErrorCode.INVALID_COMMENT_INFO);
+        }
+    }
+
+    public void validateOwner(Long requestMemberId) {
+        if (!this.memberId.equals(requestMemberId)) {
+            throw new CommentException(CommentErrorCode.NOT_COMMENT_OWNER);
+        }
+    }
+
+    private void validateContent(CommentContent content) {
+        if (content == null) {
             throw new CommentException(CommentErrorCode.INVALID_COMMENT_INFO);
         }
     }

--- a/src/main/java/econovation/moongtaengi/study/domain/comment/Comment.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/comment/Comment.java
@@ -1,0 +1,42 @@
+package econovation.moongtaengi.study.domain.comment;
+
+import econovation.moongtaengi.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "comments")
+public class Comment extends BaseEntity {
+    @Column(nullable = false)
+    private Long submissionId;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Embedded
+    private CommentContent content;
+
+    private Comment(Long submissionId, Long memberId, CommentContent content) {
+        this.submissionId = submissionId;
+        this.memberId = memberId;
+        this.content = content;
+    }
+
+    public static Comment create(Long submissionId, Long memberId, CommentContent content) {
+        validate(submissionId, memberId, content);
+        return new Comment(submissionId, memberId, content);
+    }
+
+    private static void validate(Long submissionId, Long memberId, CommentContent content) {
+        if (submissionId == null || memberId == null || content == null) {
+            throw new CommentException(CommentErrorCode.INVALID_COMMENT_INFO);
+        }
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/comment/CommentContent.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/comment/CommentContent.java
@@ -1,0 +1,34 @@
+package econovation.moongtaengi.study.domain.comment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentContent {
+    public static final int MAX_LENGTH = 500;
+
+    @Column(name = "content", nullable = false, length = MAX_LENGTH)
+    private String value;
+
+    public CommentContent(String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    private void validate(String value) {
+        if (value == null || value.isBlank()) {
+            throw new CommentException(CommentErrorCode.INVALID_COMMENT_INFO);
+        }
+
+        if (value.length() > MAX_LENGTH) {
+            throw new CommentException(CommentErrorCode.CONTENT_TOO_LONG, MAX_LENGTH);
+        }
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/comment/CommentErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/comment/CommentErrorCode.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum CommentErrorCode implements ErrorCode {
     INVALID_COMMENT_INFO(HttpStatus.BAD_REQUEST, "CM_001", "댓글의 필수 정보가 누락되었습니다."),
     CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "CM_002", "댓글은 %d자를 초과할 수 없습니다."),
-    NOT_COMMENT_OWNER(HttpStatus.FORBIDDEN, "CM_003", "해당 댓글에 대한 편집 권한이 없습니다.");
+    NOT_COMMENT_OWNER(HttpStatus.FORBIDDEN, "CM_003", "해당 댓글에 대한 편집 권한이 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM_004", "존재하지 않는 댓글입니다."),
+    NO_PERMISSION(HttpStatus.FORBIDDEN, "CM_005", "댓글을 작성할 권한이 없습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/econovation/moongtaengi/study/domain/comment/CommentErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/comment/CommentErrorCode.java
@@ -1,0 +1,18 @@
+package econovation.moongtaengi.study.domain.comment;
+
+import econovation.moongtaengi.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommentErrorCode implements ErrorCode {
+    INVALID_COMMENT_INFO(HttpStatus.BAD_REQUEST, "CM_001", "댓글의 필수 정보가 누락되었습니다."),
+    CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "CM_002", "댓글은 %d자를 초과할 수 없습니다.");
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/comment/CommentErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/comment/CommentErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommentErrorCode implements ErrorCode {
     INVALID_COMMENT_INFO(HttpStatus.BAD_REQUEST, "CM_001", "댓글의 필수 정보가 누락되었습니다."),
-    CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "CM_002", "댓글은 %d자를 초과할 수 없습니다.");
+    CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "CM_002", "댓글은 %d자를 초과할 수 없습니다."),
+    NOT_COMMENT_OWNER(HttpStatus.FORBIDDEN, "CM_003", "해당 댓글에 대한 편집 권한이 없습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/econovation/moongtaengi/study/domain/comment/CommentException.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/comment/CommentException.java
@@ -1,0 +1,14 @@
+package econovation.moongtaengi.study.domain.comment;
+
+import econovation.moongtaengi.global.exception.BusinessException;
+
+public class CommentException extends BusinessException {
+
+  public CommentException(CommentErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public CommentException(CommentErrorCode errorCode, Object... args) {
+    super(errorCode, args);
+  }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/comment/CommentMemberValidator.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/comment/CommentMemberValidator.java
@@ -1,0 +1,6 @@
+package econovation.moongtaengi.study.domain.comment;
+
+public interface CommentMemberValidator {
+
+    void validate(Long memberId, Long submissionId);
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/comment/CommentRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/comment/CommentRepository.java
@@ -1,0 +1,7 @@
+package econovation.moongtaengi.study.domain.comment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/submission/SubmissionRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/submission/SubmissionRepository.java
@@ -1,9 +1,19 @@
 package econovation.moongtaengi.study.domain.submission;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SubmissionRepository extends JpaRepository<Submission, Long> {
 
     boolean existsByAssignmentId(Long assignmentId);
+
+    @Query("select p.studyId " +
+            "from Submission s " +
+            "join Assignment a on s.assignmentId = a.id " +
+            "join StudyProcess p on a.processId = p.id " +
+            "where s.id = :submissionId")
+    Optional<Long> findStudyIdById(@Param("submissionId") Long submissionId);
 
 }

--- a/src/main/java/econovation/moongtaengi/study/infra/CommentMemberValidatorImpl.java
+++ b/src/main/java/econovation/moongtaengi/study/infra/CommentMemberValidatorImpl.java
@@ -1,0 +1,31 @@
+package econovation.moongtaengi.study.infra;
+
+import econovation.moongtaengi.study.domain.StudyMemberRepository;
+import econovation.moongtaengi.study.domain.comment.CommentErrorCode;
+import econovation.moongtaengi.study.domain.comment.CommentException;
+import econovation.moongtaengi.study.domain.comment.CommentMemberValidator;
+import econovation.moongtaengi.study.domain.submission.SubmissionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class CommentMemberValidatorImpl implements CommentMemberValidator {
+
+    private final SubmissionRepository submissionRepository;
+    private final StudyMemberRepository studyMemberRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public void validate(Long memberId, Long submissionId) {
+        Long studyId = submissionRepository.findStudyIdById(submissionId)
+                .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+        boolean isStudyMember = studyMemberRepository.existsByStudyIdAndMemberId(studyId, memberId);
+
+        if (!isStudyMember) {
+            throw new CommentException(CommentErrorCode.NO_PERMISSION);
+        }
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/api/CommentControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/CommentControllerTest.java
@@ -1,0 +1,72 @@
+package econovation.moongtaengi.study.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import econovation.moongtaengi.global.config.WebConfig;
+import econovation.moongtaengi.global.security.CustomAuthentication;
+import econovation.moongtaengi.global.security.LoginMemberIdArgumentResolver;
+import econovation.moongtaengi.study.api.dto.CommentCreateRequest;
+import econovation.moongtaengi.study.application.comment.CreateCommentCommand;
+import econovation.moongtaengi.study.application.comment.CreateCommentService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(CommentController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({WebConfig.class, LoginMemberIdArgumentResolver.class})
+@MockitoBean(types = JpaMetamodelMappingContext.class)
+public class CommentControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private CreateCommentService createCommentService;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.getContext().setAuthentication(new CustomAuthentication(1L));
+    }
+
+    @Test
+    @DisplayName("댓글 생성 요청 시 201 Created와 Location 헤더를 반환한다.")
+    void 댓글_생성_성공() throws Exception {
+        Long submissionId = 100L;
+        Long createdCommentId = 10L;
+        String content = "테스트 댓글";
+
+        CommentCreateRequest request = new CommentCreateRequest(content);
+        CreateCommentCommand command = request.toCommand(1L, submissionId);
+
+        given(createCommentService.createComment(any(CreateCommentCommand.class)))
+                .willReturn(createdCommentId);
+
+        //when&then
+        mockMvc.perform(post("/api/submissions/{submissionId}/comments", submissionId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/api/comments/" + createdCommentId));
+
+        verify(createCommentService).createComment(command);
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/application/CreateCommentServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/CreateCommentServiceTest.java
@@ -1,0 +1,66 @@
+package econovation.moongtaengi.study.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
+
+import econovation.moongtaengi.study.application.comment.CreateCommentCommand;
+import econovation.moongtaengi.study.application.comment.CreateCommentService;
+import econovation.moongtaengi.study.domain.comment.Comment;
+import econovation.moongtaengi.study.domain.comment.CommentMemberValidator;
+import econovation.moongtaengi.study.domain.comment.CommentRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CreateCommentServiceTest {
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private CommentMemberValidator commentMemberValidator;
+
+    @Captor
+    private ArgumentCaptor<Comment> commentCaptor;
+
+    @InjectMocks
+    private CreateCommentService createCommentService;
+
+    @Test
+    @DisplayName("Command를 받아 검증 후 댓글을 생성한다.")
+    void 댓글_생성_성공() {
+        //given
+        Long memberId = 1L;
+        Long submissionId = 100L;
+        String content = "테스트 댓글";
+
+        CreateCommentCommand command = new CreateCommentCommand(
+                memberId,
+                submissionId,
+                content
+        );
+
+        willDoNothing().given(commentMemberValidator)
+                .validate(memberId, submissionId);
+
+        //when
+        createCommentService.createComment(command);
+
+        //then
+        verify(commentMemberValidator).validate(memberId, submissionId);
+        verify(commentRepository).save(commentCaptor.capture());
+
+        Comment savedComment = commentCaptor.getValue();
+
+        assertThat(savedComment.getSubmissionId()).isEqualTo(submissionId);
+        assertThat(savedComment.getMemberId()).isEqualTo(memberId);
+        assertThat(savedComment.getContent().getValue()).isEqualTo(content);
+    }
+
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/comment/CommentTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/comment/CommentTest.java
@@ -1,0 +1,78 @@
+package econovation.moongtaengi.study.domain.comment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class CommentTest {
+    @Nested
+    @DisplayName("댓글 내용(VO) 검증")
+    class CommentContentTest {
+        @Test
+        @DisplayName("댓글 내용은 null이거나 빈 공백일 수 없다")
+        void 댓글_널_공백_실패() {
+            //when&then
+            assertThatThrownBy(() -> new CommentContent(null))
+                    .isInstanceOf(CommentException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(CommentErrorCode.INVALID_COMMENT_INFO);
+
+            assertThatThrownBy(() -> new CommentContent(""))
+                    .isInstanceOf(CommentException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(CommentErrorCode.INVALID_COMMENT_INFO);
+        }
+
+        @Test
+        @DisplayName("댓글 내용은 500자를 넘길 수 없다")
+        void 댓글_500자_실패() {
+            //given
+            String tooLongContent = "a".repeat(501);
+
+            //when&then
+            assertThatThrownBy(() -> new CommentContent(tooLongContent))
+                    .isInstanceOf(CommentException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(CommentErrorCode.CONTENT_TOO_LONG);
+        }
+    }
+
+    @Nested
+    @DisplayName("댓글 동작 검증")
+    class CommentEntityTest {
+
+        @Test
+        @DisplayName("댓글 생성 성공")
+        void 댓글_생성_성공() {
+            //given
+            Long submissionId = 1L;
+            Long memberId = 100L;
+            CommentContent content = new CommentContent("댓글 내용입니다.");
+
+            //when
+            Comment comment = Comment.create(submissionId, memberId, content);
+
+            //then
+            assertThat(comment.getSubmissionId()).isEqualTo(submissionId);
+            assertThat(comment.getMemberId()).isEqualTo(memberId);
+            assertThat(comment.getContent().getValue()).isEqualTo("댓글 내용입니다.");
+        }
+
+        @Test
+        @DisplayName("필수 정보가 누락되면 생성할 수 없다")
+        void 필수_정보_누락_댓글_생성_실패() {
+            //given
+            CommentContent content = new CommentContent("내용");
+
+            //when&then
+            assertThatThrownBy(() -> Comment.create(null, 1L, content))
+                    .isInstanceOf(CommentException.class);
+
+            assertThatThrownBy(() -> Comment.create(1L, null, content))
+                    .isInstanceOf(CommentException.class);
+        }
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/comment/CommentTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/comment/CommentTest.java
@@ -50,7 +50,7 @@ public class CommentTest {
             //given
             Long submissionId = 1L;
             Long memberId = 100L;
-            CommentContent content = new CommentContent("댓글 내용입니다.");
+            CommentContent content = new CommentContent("테스트 댓글 내용");
 
             //when
             Comment comment = Comment.create(submissionId, memberId, content);
@@ -58,14 +58,14 @@ public class CommentTest {
             //then
             assertThat(comment.getSubmissionId()).isEqualTo(submissionId);
             assertThat(comment.getMemberId()).isEqualTo(memberId);
-            assertThat(comment.getContent().getValue()).isEqualTo("댓글 내용입니다.");
+            assertThat(comment.getContent().getValue()).isEqualTo("테스트 댓글 내용");
         }
 
         @Test
         @DisplayName("필수 정보가 누락되면 생성할 수 없다")
         void 필수_정보_누락_댓글_생성_실패() {
             //given
-            CommentContent content = new CommentContent("내용");
+            CommentContent content = new CommentContent("테스트 댓글 내용");
 
             //when&then
             assertThatThrownBy(() -> Comment.create(null, 1L, content))
@@ -73,6 +73,37 @@ public class CommentTest {
 
             assertThatThrownBy(() -> Comment.create(1L, null, content))
                     .isInstanceOf(CommentException.class);
+        }
+
+        @Test
+        @DisplayName("작성자 본인만 댓글 수정이 가능하다")
+        void 댓글_본인_수정_성공() {
+            //given
+            Long memberId = 100L;
+            Comment comment = Comment.create(1L, memberId, new CommentContent("원본"));
+            CommentContent newContent = new CommentContent("수정 내용");
+
+            //when
+            comment.updateContent(memberId, newContent);
+
+            //then
+            assertThat(comment.getContent().getValue()).isEqualTo("수정 내용");
+        }
+
+        @Test
+        @DisplayName("댓글 작성자가 아닌 멤버가 수정을 시도하면 예외가 발생한다")
+        void 댓글_본인_아님_수정_실패() {
+            //given
+            Long ownerId = 100L;
+            Long otherId = 999L;
+            Comment comment = Comment.create(1L, ownerId, new CommentContent("원본"));
+            CommentContent newContent = new CommentContent("수정 내용");
+
+            //when&then
+            assertThatThrownBy(() -> comment.updateContent(otherId, newContent))
+                    .isInstanceOf(CommentException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(CommentErrorCode.NOT_COMMENT_OWNER);
         }
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/domain/submission/SubmissionRepositoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/submission/SubmissionRepositoryTest.java
@@ -3,6 +3,13 @@ package econovation.moongtaengi.study.domain.submission;
 import static econovation.moongtaengi.study.domain.submission.SubmissionFixture.aSubmission;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import econovation.moongtaengi.study.domain.StudyProcessFixture;
+import econovation.moongtaengi.study.domain.assignment.Assignment;
+import econovation.moongtaengi.study.domain.assignment.AssignmentFixture;
+import econovation.moongtaengi.study.domain.assignment.AssignmentRepository;
+import econovation.moongtaengi.study.domain.process.StudyProcess;
+import econovation.moongtaengi.study.domain.process.StudyProcessRepository;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +20,10 @@ public class SubmissionRepositoryTest {
 
     @Autowired
     private SubmissionRepository submissionRepository;
+    @Autowired
+    private AssignmentRepository assignmentRepository;
+    @Autowired
+    private StudyProcessRepository studyProcessRepository;
 
     @Test
     @DisplayName("과제 ID로 제출 내역 존재 여부를 확인한다.")
@@ -33,5 +44,34 @@ public class SubmissionRepositoryTest {
         //then
         assertThat(exists).isTrue();
         assertThat(notExists).isFalse();
+    }
+
+    @Test
+    @DisplayName("제출물 ID로 연관된 스터디 ID를 조회한다.")
+    void 제출물ID로_스터디ID_조회_성공() {
+        //given
+        Long expectedStudyId = 777L;
+        Long submitterId = 1L;
+
+        StudyProcess process = StudyProcessFixture.aStudyProcess(expectedStudyId);
+        studyProcessRepository.save(process);
+
+        Assignment assignment = AssignmentFixture.anAssignment()
+                .processId(process.getId())
+                .build();
+        assignmentRepository.save(assignment);
+
+        Submission submission = SubmissionFixture.aSubmission()
+                        .assignmentId(assignment.getId())
+                        .submitterId(submitterId)
+                        .build();
+        submissionRepository.save(submission);
+
+        //when
+        Optional<Long> result = submissionRepository.findStudyIdById(submission.getId());
+
+        //then
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEqualTo(expectedStudyId);
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/infra/CommentMemberValidatorImplTest.java
+++ b/src/test/java/econovation/moongtaengi/study/infra/CommentMemberValidatorImplTest.java
@@ -1,0 +1,85 @@
+package econovation.moongtaengi.study.infra;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.BDDMockito.given;
+
+import econovation.moongtaengi.study.domain.StudyMemberRepository;
+import econovation.moongtaengi.study.domain.comment.CommentErrorCode;
+import econovation.moongtaengi.study.domain.comment.CommentException;
+import econovation.moongtaengi.study.domain.submission.SubmissionRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CommentMemberValidatorImplTest {
+    @Mock
+    private SubmissionRepository submissionRepository;
+
+    @Mock
+    private StudyMemberRepository studyMemberRepository;
+
+    @InjectMocks
+    private CommentMemberValidatorImpl validator;
+
+    @Test
+    @DisplayName("스터디원이고 제출물이 존재하면 통과한다.")
+    void 스터디원_제출물_존재_검증_성공() {
+        //given
+        Long memberId = 1L;
+        Long submissionId = 100L;
+        Long studyId = 777L;
+
+        given(submissionRepository.findStudyIdById(submissionId))
+                .willReturn(Optional.of(studyId));
+
+        given(studyMemberRepository.existsByStudyIdAndMemberId(studyId, memberId))
+                .willReturn(true);
+
+        //when&then
+        assertDoesNotThrow(() -> validator.validate(memberId, submissionId));
+    }
+
+    @Test
+    @DisplayName("제출물이 존재하지 않으면 예외가 발생한다.")
+    void 제출물_없음_검증_실패() {
+        //given
+        Long memberId = 1L;
+        Long submissionId = 999L;
+
+        given(submissionRepository.findStudyIdById(submissionId))
+                .willReturn(Optional.empty());
+
+        //when&then
+        assertThatThrownBy(() -> validator.validate(memberId, submissionId))
+                .isInstanceOf(CommentException.class)
+                .extracting("errorCode")
+                .isEqualTo(CommentErrorCode.COMMENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("스터디원이 아니면 예외가 발생한다.")
+    void 스터디원_아님_검증_실패() {
+        // given
+        Long memberId = 2L;
+        Long submissionId = 100L;
+        Long studyId = 777L;
+
+        given(submissionRepository.findStudyIdById(submissionId))
+                .willReturn(Optional.of(studyId));
+
+        given(studyMemberRepository.existsByStudyIdAndMemberId(studyId, memberId))
+                .willReturn(false);
+
+        //when&then
+        assertThatThrownBy(() -> validator.validate(memberId, submissionId))
+                .isInstanceOf(CommentException.class)
+                .extracting("errorCode")
+                .isEqualTo(CommentErrorCode.NO_PERMISSION);
+    }
+}


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
Domain 계층
- Comment 엔티티 및 정적 팩토리 메서드(create) 정의
- CommentContent VO(Value Object) 구현
  - JPA @Embeddable 적용 및 불변 객체 설계
  - 500자 길이 제한 및 필수값 검증 로직 캡슐화
- 댓글 수정 비즈니스 로직(updateContent) 구현
- 엔티티 내부 검증 로직 책임 분리 및 세분화
  - validateCreation: 생성 시점 필수 필드 검증
  - validateContent: VO 유효성 검증
  - validateOwner: 편집 권한 검증
- 에러 코드 정의 (CommentErrorCode)

Infrastructure 및 Validation
- CommentMemberValidator 인터페이스 및 구현체 추가
- 제출물이 속한 스터디의 구성원인지 확인하는 도메인 로직 구현
- SubmissionRepository 쿼리 메서드 추가
  - findStudyIdById: Submission, Assignment, StudyProcess를 조인하여 스터디 ID 조회

Application 계층
- CreateCommentService 구현
  - 검증(Validator)과 저장(Repository) 로직 조율
- CreateCommentCommand 추가
  - 서비스 계층의 입력 모델로 사용하여 컨트롤러와의 결합도 감소
- CommentRepository 인터페이스 정의

Presentation 계층
- CommentController 구현
  - API 엔드포인트: POST /api/submissions/{submissionId}/comments
- CommentCreateRequest DTO 추가
  - @LoginMemberId와 PathVariable을 조합하여 Command로 변환하는 팩토리 메서드 포함

테스트
- Domain: 엔티티 생성/수정 성공 및 예외 케이스(길이 초과, 권한 없음 등) 검증
- Repository: @DataJpaTest를 활용한 연관관계 조인 쿼리 테스트
- Service: Mockito와 ArgumentCaptor를 활용한 엔티티 생성 및 값 검증
- Controller: @WebMvcTest를 활용한 요청 매핑 및 Service 호출 검증 (refEq/verify 활용)
### 🧪 테스트 결과
- [x] 테스트 코드 모두 통과했습니다! 
- [x] 포스트맨 활용 테스트
<img width="669" height="340" alt="image" src="https://github.com/user-attachments/assets/fda13dc5-5d60-4a91-bcc7-8a888c6f04d4" />
 
### 👿 트러블 슈팅
1. API 설계와 애그리게이트 분리 간의 괴리 해결
- 문제 상황
  - DDD 원칙에 따라 Submission과 Comment를 서로 다른 애그리게이트로 분리하여 물리적 결합을 끊음
  - API 설계 시 RESTful 리소스 관계 표현(/submissions/{id}/comments)과 애그리게이트의 독립성(/comments) 사이에서 충돌 발생
- 해결
  - 백엔드 구현: 트랜잭션 분리와 성능 최적화를 위해 별도 애그리게이트 유지 (Comment는 SubmissionId만 참조)
  - API 인터페이스: 클라이언트의 직관적인 사용 흐름을 위해 생성 및 목록 조회는 계층형 URL(/submissions/{id}/comments)을 채택하고, 단건 수정/삭제는 플랫형 URL(/comments/{id})을 채택하는 하이브리드 전략 적용예정

2. 도메인 간 결합도를 낮추기 위한 에러 코드 리팩토링
- 문제 상황
  - 댓글 작성 권한 검증 시 NOT_STUDY_MEMBER라는 에러 코드를 사용하여 Comment 도메인이 Study 도메인의 문맥에 의존하게 됨
- 해결
  - NO_PERMISSION이라는 중립적인 에러 코드로 변경하여 Comment 도메인의 순수성을 유지하고 재사용성을 확보
### 💬 코멘트
바로 댓글 수정 쪽 작업하도록 하겠습니다! 궁금한 점 있으시면 말씀해주세요!! 

