### PR TITLE
feat: 뭉탱이 이미지 응답 방법 수정 및 이미지 주소 연결

### DIFF
--- a/src/main/java/econovation/moongtaengi/collection/application/CollectionEventListener.java
+++ b/src/main/java/econovation/moongtaengi/collection/application/CollectionEventListener.java
@@ -99,7 +99,7 @@ public class CollectionEventListener {
                 event.memberId(), event.collectionType());
 
         // TREASURE_BAG 자기 자신 해금 방지
-        if (event.collectionType() == CollectionType.TREASURE_BAG) {
+        if (event.collectionType() == CollectionType.TREASURE) {
             return;
         }
 
@@ -108,7 +108,7 @@ public class CollectionEventListener {
 
         // 7개 이상이면 TREASURE_BAG 해금
         if (collectionCount >= 7) {
-            collectionService.unlockCollection(event.memberId(), CollectionType.TREASURE_BAG);
+            collectionService.unlockCollection(event.memberId(), CollectionType.TREASURE);
             log.info("회원 {}에게 TREASURE_BAG 컬렉션이 해금되었습니다 (총 컬렉션: {}개)",
                     event.memberId(), collectionCount);
         }
@@ -116,16 +116,16 @@ public class CollectionEventListener {
 
     /**
      * 온보딩 미션 전체 완료 이벤트 처리
-     * WOODEN_PICKAXE 컬렉션 해금 (보상)
+     * WOOD 컬렉션 해금 (보상)
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleOnboardingMissionCompleted(OnboardingMissionCompletedEvent event) {
         log.info("온보딩 미션 전체 완료 이벤트 수신 - memberId: {}", event.memberId());
 
-        // WOODEN_PICKAXE 컬렉션 해금 (온보딩 완료 보상)
-        collectionService.unlockCollection(event.memberId(), CollectionType.WOODEN_PICKAXE);
-        log.info("회원 {}에게 WOODEN_PICKAXE 컬렉션이 해금되었습니다 (온보딩 완료 보상)",
+        // WOOD 컬렉션 해금 (온보딩 완료 보상)
+        collectionService.unlockCollection(event.memberId(), CollectionType.WOOD);
+        log.info("회원 {}에게 나무곡괭이 뭉탱이 컬렉션이 해금되었습니다 (온보딩 완료 보상)",
                 event.memberId());
     }
 }

--- a/src/main/java/econovation/moongtaengi/collection/application/CollectionService.java
+++ b/src/main/java/econovation/moongtaengi/collection/application/CollectionService.java
@@ -59,6 +59,9 @@ public class CollectionService {
                     Collection collection = unlockedMap.get(type);
                     boolean unlocked = collection != null;
 
+                    // 해금 여부에 따라 적절한 이미지 URL 선택
+                    String imageUrl = unlocked ? type.getUnlockedImageUrl() : type.getLockedImageUrl();
+
                     return new CollectionInfo(
                             type,
                             type.getDisplayName(),
@@ -66,7 +69,7 @@ public class CollectionService {
                             type.getDescription(),
                             unlocked,
                             unlocked ? collection.getUnlockedAt() : null,
-                            type.getImageUrl()
+                            imageUrl
                     );
                 })
                 .toList();
@@ -93,6 +96,9 @@ public class CollectionService {
 
         boolean unlocked = collection != null;
 
+        // 해금 여부에 따라 적절한 이미지 URL 선택
+        String imageUrl = unlocked ? collectionType.getUnlockedImageUrl() : collectionType.getLockedImageUrl();
+
         log.info("회원 {}의 컬렉션 {} 상세 정보를 조회했습니다", memberId, collectionType);
 
         return new CollectionInfo(
@@ -102,7 +108,7 @@ public class CollectionService {
                 collectionType.getDescription(),
                 unlocked,
                 unlocked ? collection.getUnlockedAt() : null,
-                collectionType.getImageUrl()
+                imageUrl
         );
     }
 

--- a/src/main/java/econovation/moongtaengi/collection/domain/CollectionType.java
+++ b/src/main/java/econovation/moongtaengi/collection/domain/CollectionType.java
@@ -14,21 +14,28 @@ public enum CollectionType {
             "기본 뭉탱이",
             CollectionRarity.COMMON,
             "회원가입 시 기본 지급",
-            "https://s3.ap-northeast-2.amazonaws.com/moongtaengi-bucket/collections/default.png"
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/default/default1.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/default/default2.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/default/default_bg.png"
     ),
 
     // 특별 코드 (스터디 참여 시 inviteCode로 해금)
-    ECONO_SPECIAL(
+    ECONO(
             "에코노 뭉탱이",
             CollectionRarity.COMMON,
             "에코노 코드로 스터디 참여",
-            "https://s3.ap-northeast-2.amazonaws.com/moongtaengi-bucket/collections/econo-special.png"
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/econo/econo1.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/econo/econo2.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/econo/econo_bg.png"
     ),
+
     SPECIAL(
             "스페셜 뭉탱이",
             CollectionRarity.RARE,
             "스페셜 코드로 스터디 참여",
-            "https://s3.ap-northeast-2.amazonaws.com/moongtaengi-bucket/collections/special.png"
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/special/special1.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/special/special2.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/special/special_bg.png"
     ),
 
     // 경험치 기반
@@ -36,13 +43,18 @@ public enum CollectionType {
             "프로 뭉탱이",
             CollectionRarity.RARE,
             "100 XP 달성",
-            "https://s3.ap-northeast-2.amazonaws.com/moongtaengi-bucket/collections/pro.png"
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/pro/pro1.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/pro/pro2.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/pro/pro_bg.png"
     ),
+
     MASTER(
             "마스터 뭉탱이",
             CollectionRarity.EPIC,
             "300 XP 달성",
-            "https://s3.ap-northeast-2.amazonaws.com/moongtaengi-bucket/collections/master.png"
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/master/master1.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/master/master2.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/master/master_bg.png"
     ),
 
     // 스터디 활동
@@ -50,34 +62,84 @@ public enum CollectionType {
             "뭉탱이 다발",
             CollectionRarity.EPIC,
             "4인 이상 스터디 참여",
-            "https://s3.ap-northeast-2.amazonaws.com/moongtaengi-bucket/collections/bunch.png"
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/bunch/bunch1.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/bunch/bunch2.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/bunch/bunch_bg.png"
     ),
 
     // 컬렉션 수집
-    TREASURE_BAG(
+    TREASURE(
             "보물주머니 뭉탱이",
             CollectionRarity.UNIQUE,
             "7개 이상 컬렉션 해금",
-            "https://s3.ap-northeast-2.amazonaws.com/moongtaengi-bucket/collections/treasure-bag.png"
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/treasure/treasure1.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/treasure/treasure2.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/treasure/treasure_bg.png"
     ),
 
     // 온보딩 완료
-    WOODEN_PICKAXE(
+    WOOD(
             "나무곡괭이 뭉탱이",
             CollectionRarity.COMMON,
             "모든 온보딩 미션 완료",
-            "https://s3.ap-northeast-2.amazonaws.com/moongtaengi-bucket/collections/wooden-pickaxe.png"
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood1.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood2.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood_bg.png"
+    ),
+
+    // 댓글 작성
+    GRADUATION(
+            "학사모 뭉탱이",
+            CollectionRarity.EPIC,
+            "댓글 10개 작성하기",
+                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood1.png",
+                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood2.png",
+                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood_bg.png"
+    ),
+
+    KANE(
+            "케인 뭉탱이",
+            CollectionRarity.UNIQUE,
+            "댓글 100개 작성하기",
+                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood1.png",
+                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood2.png",
+                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood_bg.png"
+    ),
+
+    // 감정표현
+    STICKER(
+            "스티커 뭉탱이",
+            CollectionRarity.RARE,
+            "감정 표현 사용하기",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood1.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood2.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood_bg.png"
+    ),
+
+    // 탑러너
+    TOP_RUNNER(
+            "탑러너 뭉탱이",
+            CollectionRarity.UNIQUE,
+            "탑러너에 입성하기",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood1.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood2.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood_bg.png"
     );
 
     private final String displayName;
     private final CollectionRarity rarity;
     private final String description;
-    private final String imageUrl;
+    private final String lockedImageUrl;      // 잠금 상태 이미지 (흐릿한 이미지)
+    private final String unlockedImageUrl;    // 해금 상태 이미지 (원본 이미지)
+    private final String backgroundImageUrl;  // 메인 페이지 배경용 이미지 (향후 사용)
 
-    CollectionType(String displayName, CollectionRarity rarity, String description, String imageUrl) {
+    CollectionType(String displayName, CollectionRarity rarity, String description,
+                   String lockedImageUrl, String unlockedImageUrl, String backgroundImageUrl) {
         this.displayName = displayName;
         this.rarity = rarity;
         this.description = description;
-        this.imageUrl = imageUrl;
+        this.lockedImageUrl = lockedImageUrl;
+        this.unlockedImageUrl = unlockedImageUrl;
+        this.backgroundImageUrl = backgroundImageUrl;
     }
 }

--- a/src/main/java/econovation/moongtaengi/onboarding/application/OnboardingService.java
+++ b/src/main/java/econovation/moongtaengi/onboarding/application/OnboardingService.java
@@ -30,6 +30,7 @@ public class OnboardingService {
      * @param memberId 회원 ID
      * @return 온보딩 미션 (항상 반환, null 아님)
      */
+    @Transactional
     public OnboardingMissionResponse getOnboardingMission(Long memberId) {
         // existingMission: 상태와 무관하게 회원에게 할당된 미션이 존재하는지 확인
         // WAITING 또는 COMPLETED 상태 모두 반환

--- a/src/main/java/econovation/moongtaengi/study/application/JoinStudyService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/JoinStudyService.java
@@ -54,7 +54,7 @@ public class JoinStudyService {
      */
     private void checkAndUnlockSpecialCollection(Long memberId, String inviteCode) {
         if (ECONO_CODE.equals(inviteCode)) {
-            collectionService.unlockCollection(memberId, CollectionType.ECONO_SPECIAL);
+            collectionService.unlockCollection(memberId, CollectionType.ECONO);
             log.info("회원 {}에게 특별 코드로 ECONO_SPECIAL 컬렉션이 해금되었습니다", memberId);
         } else if (SPECIAL_CODE.equals(inviteCode)) {
             collectionService.unlockCollection(memberId, CollectionType.SPECIAL);


### PR DESCRIPTION
### 📌 PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
- 실제 이미지 URL 적용
- 잠금 상태에 따라 블러 처리 된 이미지, 블러 안된 이미지 URL 제공
- 메인페이지에 쓸 배경 이미지도 저장, 추후 메인 페이지 API 때 사용
- 케인, 학사모, 탑러너, 스티커 뭉탱이 ENUM에 추가 구현 완료, 발급 로직은 추후에 할 예정

### 🧪 테스트 결과

### 👿 트러블 슈팅

### 💬 코멘트



