### PR TITLE
feat: 댓글 수정 API 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/api/AssignmentController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/AssignmentController.java
@@ -54,6 +54,8 @@ public class AssignmentController {
             @LoginMemberId Long memberId,
             @RequestParam Long processId
     ) {
+        log.info("과제 목록 조회 API 호출 - requesterId: {}, processId: {}", memberId, processId);
+
         List<AssignmentSummary> response = assignmentQueryService.getAssignmentSummaries(memberId, processId);
 
         return ResponseEntity.ok(response);
@@ -64,6 +66,8 @@ public class AssignmentController {
             @LoginMemberId Long memberId,
             @PathVariable Long assignmentId
     ) {
+        log.info("과제 상세 조회 API 호출 - requesterId: {}, assignmentId: {}", memberId, assignmentId);
+
         AssignmentDetail response = assignmentQueryService.getAssignmentDetail(memberId, assignmentId);
 
         return ResponseEntity.ok(response);

--- a/src/main/java/econovation/moongtaengi/study/api/CommentController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/CommentController.java
@@ -2,13 +2,17 @@ package econovation.moongtaengi.study.api;
 
 import econovation.moongtaengi.global.annotation.LoginMemberId;
 import econovation.moongtaengi.study.api.dto.CommentCreateRequest;
+import econovation.moongtaengi.study.api.dto.CommentUpdateRequest;
 import econovation.moongtaengi.study.application.comment.CreateCommentCommand;
 import econovation.moongtaengi.study.application.comment.CreateCommentService;
+import econovation.moongtaengi.study.application.comment.UpdateCommentService;
+import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,17 +23,29 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController {
 
     private final CreateCommentService createCommentService;
+    private final UpdateCommentService updateCommentService;
 
     @PostMapping("/submissions/{submissionId}/comments")
     public ResponseEntity<Void> createComment(
             @LoginMemberId Long memberId,
             @PathVariable Long submissionId,
-            @RequestBody CommentCreateRequest request
+            @RequestBody @Valid CommentCreateRequest request
     ) {
         CreateCommentCommand command = request.toCommand(memberId, submissionId);
 
         Long commentId = createCommentService.createComment(command);
 
         return ResponseEntity.created(URI.create("/api/comments/" + commentId)).build();
+    }
+
+    @PutMapping("/comments/{commentId}")
+    public ResponseEntity<Void> updateComment(
+            @LoginMemberId Long memberId,
+            @PathVariable Long commentId,
+            @RequestBody @Valid CommentUpdateRequest request
+    ) {
+        updateCommentService.updateComment(request.toCommand(commentId, memberId));
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/api/CommentController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/CommentController.java
@@ -9,6 +9,7 @@ import econovation.moongtaengi.study.application.comment.UpdateCommentService;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -31,6 +33,8 @@ public class CommentController {
             @PathVariable Long submissionId,
             @RequestBody @Valid CommentCreateRequest request
     ) {
+        log.info("댓글 생성 API 호출 - memberId: {}, submissionId: {}", memberId, submissionId);
+
         CreateCommentCommand command = request.toCommand(memberId, submissionId);
 
         Long commentId = createCommentService.createComment(command);
@@ -44,6 +48,8 @@ public class CommentController {
             @PathVariable Long commentId,
             @RequestBody @Valid CommentUpdateRequest request
     ) {
+        log.info("댓글 수정 API 호출 - memberId: {}, commentId: {}", memberId, commentId);
+
         updateCommentService.updateComment(request.toCommand(commentId, memberId));
 
         return ResponseEntity.ok().build();

--- a/src/main/java/econovation/moongtaengi/study/api/dto/CommentCreateRequest.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/CommentCreateRequest.java
@@ -1,8 +1,10 @@
 package econovation.moongtaengi.study.api.dto;
 
 import econovation.moongtaengi.study.application.comment.CreateCommentCommand;
+import jakarta.validation.constraints.NotBlank;
 
 public record CommentCreateRequest(
+        @NotBlank(message = "댓글 내용은 필수입니다.")
         String content
 ) {
     public CreateCommentCommand toCommand(Long memberId, Long submissionId) {

--- a/src/main/java/econovation/moongtaengi/study/api/dto/CommentUpdateRequest.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/CommentUpdateRequest.java
@@ -1,0 +1,13 @@
+package econovation.moongtaengi.study.api.dto;
+
+import econovation.moongtaengi.study.application.comment.UpdateCommentCommand;
+import jakarta.validation.constraints.NotBlank;
+
+public record CommentUpdateRequest(
+        @NotBlank(message = "댓글 내용은 필수입니다.")
+        String content
+) {
+    public UpdateCommentCommand toCommand(Long commentId, Long memberId) {
+        return new UpdateCommentCommand(commentId, memberId, content);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/application/comment/CreateCommentService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/comment/CreateCommentService.java
@@ -27,6 +27,9 @@ public class CreateCommentService {
 
         commentRepository.save(comment);
 
+        log.info("댓글 생성 성공 - commentId: {}, memberId: {}, submissionId: {}",
+                comment.getId(), command.memberId(), command.submissionId());
+
         return comment.getId();
     }
 

--- a/src/main/java/econovation/moongtaengi/study/application/comment/UpdateCommentCommand.java
+++ b/src/main/java/econovation/moongtaengi/study/application/comment/UpdateCommentCommand.java
@@ -1,0 +1,8 @@
+package econovation.moongtaengi.study.application.comment;
+
+public record UpdateCommentCommand(
+        Long commentId,
+        Long memberId,
+        String content
+) {
+}

--- a/src/main/java/econovation/moongtaengi/study/application/comment/UpdateCommentService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/comment/UpdateCommentService.java
@@ -8,6 +8,7 @@ import econovation.moongtaengi.study.domain.comment.CommentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -16,6 +17,7 @@ public class UpdateCommentService {
 
     private final CommentRepository commentRepository;
 
+    @Transactional
     public void updateComment(UpdateCommentCommand command) {
         Comment comment = commentRepository.findById(command.commentId())
                 .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));

--- a/src/main/java/econovation/moongtaengi/study/application/comment/UpdateCommentService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/comment/UpdateCommentService.java
@@ -1,0 +1,27 @@
+package econovation.moongtaengi.study.application.comment;
+
+import econovation.moongtaengi.study.domain.comment.Comment;
+import econovation.moongtaengi.study.domain.comment.CommentContent;
+import econovation.moongtaengi.study.domain.comment.CommentErrorCode;
+import econovation.moongtaengi.study.domain.comment.CommentException;
+import econovation.moongtaengi.study.domain.comment.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UpdateCommentService {
+
+    private final CommentRepository commentRepository;
+
+    public void updateComment(UpdateCommentCommand command) {
+        Comment comment = commentRepository.findById(command.commentId())
+                .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+        CommentContent content = new CommentContent(command.content());
+
+        comment.updateContent(command.memberId(), content);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/application/comment/UpdateCommentService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/comment/UpdateCommentService.java
@@ -23,5 +23,7 @@ public class UpdateCommentService {
         CommentContent content = new CommentContent(command.content());
 
         comment.updateContent(command.memberId(), content);
+
+        log.info("댓글 수정 성공 - commentId: {}, memberId: {}", command.commentId(), command.memberId());
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/api/CommentControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/CommentControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -12,8 +13,11 @@ import econovation.moongtaengi.global.config.WebConfig;
 import econovation.moongtaengi.global.security.CustomAuthentication;
 import econovation.moongtaengi.global.security.LoginMemberIdArgumentResolver;
 import econovation.moongtaengi.study.api.dto.CommentCreateRequest;
+import econovation.moongtaengi.study.api.dto.CommentUpdateRequest;
 import econovation.moongtaengi.study.application.comment.CreateCommentCommand;
 import econovation.moongtaengi.study.application.comment.CreateCommentService;
+import econovation.moongtaengi.study.application.comment.UpdateCommentCommand;
+import econovation.moongtaengi.study.application.comment.UpdateCommentService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,6 +44,9 @@ public class CommentControllerTest {
 
     @MockitoBean
     private CreateCommentService createCommentService;
+
+    @MockitoBean
+    private UpdateCommentService updateCommentService;
 
     @BeforeEach
     void setUp() {
@@ -68,5 +75,26 @@ public class CommentControllerTest {
                 .andExpect(header().string("Location", "/api/comments/" + createdCommentId));
 
         verify(createCommentService).createComment(command);
+    }
+    @Test
+    @DisplayName("댓글 수정 요청 시 서비스를 호출하고 200 OK를 반환한다.")
+    void 댓글_수정_성공() throws Exception {
+        //given
+        Long commentId = 1L;
+        Long memberId = 1L;
+        String newContent = "수정된 댓글 내용입니다.";
+
+        CommentUpdateRequest request = new CommentUpdateRequest(newContent);
+
+        UpdateCommentCommand expectedCommand = new UpdateCommentCommand(commentId, memberId, newContent);
+
+        //when&then
+        mockMvc.perform(put("/api/comments/{commentId}", commentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isOk());
+
+        verify(updateCommentService).updateComment(expectedCommand);
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/application/UpdateCommentServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/UpdateCommentServiceTest.java
@@ -1,0 +1,76 @@
+package econovation.moongtaengi.study.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import econovation.moongtaengi.study.application.comment.UpdateCommentCommand;
+import econovation.moongtaengi.study.application.comment.UpdateCommentService;
+import econovation.moongtaengi.study.domain.comment.Comment;
+import econovation.moongtaengi.study.domain.comment.CommentContent;
+import econovation.moongtaengi.study.domain.comment.CommentErrorCode;
+import econovation.moongtaengi.study.domain.comment.CommentException;
+import econovation.moongtaengi.study.domain.comment.CommentRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UpdateCommentServiceTest {
+    @Mock
+    private CommentRepository commentRepository;
+
+    @InjectMocks
+    private UpdateCommentService updateCommentService;
+
+    @Test
+    @DisplayName("본인의 댓글 내용을 정상적으로 수정한다.")
+    void 댓글_수정_성공() {
+        //given
+        Long commentId = 1L;
+        Long ownerId = 100L;
+        String oldContent = "기존 내용";
+        String newContent = "수정된 내용";
+
+        Comment comment = Comment.create(
+                999L,
+                ownerId,
+                new CommentContent(oldContent)
+        );
+
+        given(commentRepository.findById(commentId))
+                .willReturn(Optional.of(comment));
+
+        UpdateCommentCommand command = new UpdateCommentCommand(commentId, ownerId, newContent);
+
+        // when
+        updateCommentService.updateComment(command);
+
+        //then
+        assertThat(comment.getContent().getValue()).isEqualTo(newContent);
+    }
+
+
+    @Test
+    @DisplayName("존재하지 않는 댓글 ID로 요청 시 예외가 발생한다.")
+    void 댓글_수정_댓글_없음_실패() {
+        //given
+        Long invalidCommentId = 9999L;
+        Long memberId = 1L;
+
+        UpdateCommentCommand command = new UpdateCommentCommand(invalidCommentId, memberId, "테스트");
+
+        given(commentRepository.findById(invalidCommentId))
+                .willReturn(Optional.empty());
+
+        //when&then
+        assertThatThrownBy(() -> updateCommentService.updateComment(command))
+                .isInstanceOf(CommentException.class)
+                .extracting("errorCode")
+                .isEqualTo(CommentErrorCode.COMMENT_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
1. 댓글 수정 애플리케이션 계층 구현
- UpdateCommentCommand(Record)를 통해 수정 요청 데이터를 캡슐화.
- 도메인 엔티티(Comment) 내 updateContent() 메서드를 사용.
- UpdateCommentService에서 댓글 존재 여부 확인 및 수정 로직을 트랜잭션으로 처리.

2. 댓글 수정 API 구현 
- 엔드포인트: PUT /api/comments/{commentId}
- 댓글 내용은 부분 수정보다는 전체 내용 교체의 의미가 강하므로 PUT 메서드를 채택.
- CommentUpdateRequest DTO를 생성하고 @NotBlank 유효성 검증을 적용.

3. 테스트
- UpdateCommentServiceTest
  - [x] 본인 댓글 수정 성공 케이스
  - [x] 존재하지 않는 댓글 ID 요청 시 예외(COMMENT_NOT_FOUND) 발생 검증
- CommentControllerTest
  - [x] 댓글 수정 요청 시 HttpStatus(200OK) 확인 및 데이터 전달 및 서비스 호출 검증 (MockMvc, Mockito)
### 🧪 테스트 결과
- [x] 테스트 코드 모두 통과하였습니다!!
- [x] 포스트맨 테스트 
<img width="506" height="260" alt="image" src="https://github.com/user-attachments/assets/f3c7c7ba-7e69-40b7-8c07-6bd270164485" />

### 👿 트러블 슈팅
**트러블 슈팅: 댓글 수정 변경 감지 누락 문제**
1. 문제 상황
- Postman과 H2 Database를 이용한 통합 테스트 진행 중, 댓글 수정 API(`PUT /api/comments/{id}`) 호출 시 응답은 `200 OK`가 반환되었으나 실제 DB 데이터가 변경되지 않는 현상 발생
- `UpdateCommentServiceTest` 단위 테스트(Mockito 기반)는 정상적으로 통과하고 있어 원인 파악에 어려움이 있었음

2. 원인 분석
- **@Transactional 어노테이션 누락**: `UpdateCommentService`에 트랜잭션 처리가 되어 있지 않아 JPA의 변경 감지(Dirty Checking)가 동작하지 않음
- 단위 테스트의 한계: Mock 객체를 사용한 단위 테스트는 순수 자바 객체(Memory)의 필드 값 변경만 검증함. 트랜잭션 커밋 시점에 일어나는 `UPDATE` 쿼리 발행 여부는 검증할 수 없음

3. 해결
- `UpdateCommentService` 클래스에 `@Transactional` 어노테이션 추가
- 이후 Postman 테스트 재수행 결과, 정상적으로 Update 쿼리가 발생하고 DB에 반영됨을 확인

4. 배운 점
- 단위 테스트는 비즈니스 로직의 논리적 오류를 잡는 데 유효하지만, 프레임워크의 동작(트랜잭션, 영속성 컨텍스트 등)까지 보장하지 않음을 확인함
- 실제 DB 환경과 유사한 통합 테스트의 중요성을 체감함
### 💬 코멘트
PUT으로 할지 PATCH로 할지 고민하다가 댓글이라는 건 전체 내용의 교체인 의미인 것 같아서 PUT으로 했습니다! 


