### PR TITLE
feat: 과제 제출물 감정표현(Reaction) 토글 기능 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/api/ReactionController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/ReactionController.java
@@ -1,0 +1,41 @@
+package econovation.moongtaengi.study.api;
+
+import econovation.moongtaengi.global.annotation.LoginMemberId;
+import econovation.moongtaengi.study.api.dto.ReactionToggleRequest;
+import econovation.moongtaengi.study.application.reaction.ToggleReactionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ReactionController {
+
+    private final ToggleReactionService toggleReactionService;
+
+    @PostMapping("/submissions/{submissionId}/reactions")
+    public ResponseEntity<Void> toggleReaction(
+            @LoginMemberId Long memberId,
+            @PathVariable Long submissionId,
+            @RequestBody @Valid ReactionToggleRequest reactionToggleRequest
+    ) {
+        log.info("감정표현 토글 API 호출 - memberId: {}, submissionId: {}, type: {}",
+                memberId, submissionId, reactionToggleRequest.emojiType());
+
+        toggleReactionService.toggleReaction(
+                submissionId,
+                memberId,
+                reactionToggleRequest.emojiType()
+        );
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/api/dto/ReactionToggleRequest.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/ReactionToggleRequest.java
@@ -1,0 +1,10 @@
+package econovation.moongtaengi.study.api.dto;
+
+import econovation.moongtaengi.study.domain.reaction.EmojiType;
+import jakarta.validation.constraints.NotNull;
+
+public record ReactionToggleRequest(
+        @NotNull(message = "이모지 타입은 필수입니다.")
+        EmojiType emojiType
+) {
+}

--- a/src/main/java/econovation/moongtaengi/study/application/reaction/ToggleReactionService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/reaction/ToggleReactionService.java
@@ -1,0 +1,41 @@
+package econovation.moongtaengi.study.application.reaction;
+
+import econovation.moongtaengi.study.domain.reaction.EmojiType;
+import econovation.moongtaengi.study.domain.reaction.Reaction;
+import econovation.moongtaengi.study.domain.reaction.ReactionMemberValidator;
+import econovation.moongtaengi.study.domain.reaction.ReactionRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ToggleReactionService {
+
+    private final ReactionRepository reactionRepository;
+    private final ReactionMemberValidator reactionMemberValidator;
+
+    @Transactional
+    public void toggleReaction(Long submissionId, Long memberId, EmojiType emojiType) {
+        reactionMemberValidator.validate(memberId, submissionId);
+
+        Optional<Reaction> reaction = reactionRepository
+                .findBySubmissionIdAndMemberIdAndEmojiType(submissionId, memberId, emojiType);
+
+        if (reaction.isPresent()) {
+            reactionRepository.delete(reaction.get());
+
+            log.info("감정표현 취소 성공 - submissionId: {}, memberId: {}, type: {}",
+                    submissionId, memberId, emojiType);
+        } else {
+            Reaction newReaction = Reaction.create(submissionId, memberId, emojiType);
+            reactionRepository.save(newReaction);
+
+            log.info("감정표현 추가 성공 - submissionId: {}, memberId: {}, type: {}",
+                    submissionId, memberId, emojiType);
+        }
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/reaction/EmojiType.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/reaction/EmojiType.java
@@ -1,0 +1,16 @@
+package econovation.moongtaengi.study.domain.reaction;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EmojiType {
+    HEART("하트"),
+    CLAP("박수"),
+    SURPRISED("놀람"),
+    SAD("슬픔"),
+    EYES_HEART("눈하트");
+
+    private final String description;
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/reaction/Reaction.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/reaction/Reaction.java
@@ -1,0 +1,53 @@
+package econovation.moongtaengi.study.domain.reaction;
+
+import econovation.moongtaengi.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "reactions",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_reaction_submission_member_type",
+                        columnNames = {"submission_id", "member_id", "emoji_type"}
+                )
+        }
+)
+public class Reaction extends BaseEntity {
+    @Column(name = "submission_id", nullable = false)
+    private Long submissionId;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "emoji_type", nullable = false)
+    private EmojiType emojiType;
+
+    private Reaction(Long submissionId, Long memberId, EmojiType emojiType) {
+        this.submissionId = submissionId;
+        this.memberId = memberId;
+        this.emojiType = emojiType;
+    }
+
+    public static Reaction create(Long submissionId, Long memberId, EmojiType emojiType) {
+        validate(submissionId, memberId, emojiType);
+        return new Reaction(submissionId, memberId, emojiType);
+    }
+
+    private static void validate(Long submissionId, Long memberId, EmojiType emojiType) {
+        if (submissionId == null || memberId == null || emojiType == null) {
+            throw new ReactionException(ReactionErrorCode.INVALID_REACTION_INFO);
+        }
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ReactionErrorCode implements ErrorCode {
-    INVALID_REACTION_INFO(HttpStatus.BAD_REQUEST, "RT_001", "감정표현의 필수 정보가 누락되었습니다.");
+    INVALID_REACTION_INFO(HttpStatus.BAD_REQUEST, "RT_001", "감정표현의 필수 정보가 누락되었습니다."),
+    SUBMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "RT_002", "존재하지 않는 제출물입니다."),
+    NO_PERMISSION(HttpStatus.FORBIDDEN, "RT_003", "감정표현을 할 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionErrorCode.java
@@ -1,0 +1,16 @@
+package econovation.moongtaengi.study.domain.reaction;
+
+import econovation.moongtaengi.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReactionErrorCode implements ErrorCode {
+    INVALID_REACTION_INFO(HttpStatus.BAD_REQUEST, "RT_001", "감정표현의 필수 정보가 누락되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionException.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionException.java
@@ -1,0 +1,10 @@
+package econovation.moongtaengi.study.domain.reaction;
+
+import econovation.moongtaengi.global.exception.BusinessException;
+
+public class ReactionException extends BusinessException {
+
+    public ReactionException(ReactionErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionMemberValidator.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionMemberValidator.java
@@ -1,0 +1,5 @@
+package econovation.moongtaengi.study.domain.reaction;
+
+public interface ReactionMemberValidator {
+    void validate(Long memberId, Long submissionId);
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionRepository.java
@@ -1,0 +1,9 @@
+package econovation.moongtaengi.study.domain.reaction;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReactionRepository extends JpaRepository<Reaction, Long> {
+
+    Optional<Reaction> findBySubmissionIdAndMemberIdAndEmojiType(Long submissionId, Long memberId, EmojiType emojiType);
+}

--- a/src/main/java/econovation/moongtaengi/study/infra/ReactionMemberValidatorImpl.java
+++ b/src/main/java/econovation/moongtaengi/study/infra/ReactionMemberValidatorImpl.java
@@ -1,0 +1,29 @@
+package econovation.moongtaengi.study.infra;
+
+import econovation.moongtaengi.study.domain.StudyMemberRepository;
+import econovation.moongtaengi.study.domain.reaction.ReactionErrorCode;
+import econovation.moongtaengi.study.domain.reaction.ReactionException;
+import econovation.moongtaengi.study.domain.reaction.ReactionMemberValidator;
+import econovation.moongtaengi.study.domain.submission.SubmissionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReactionMemberValidatorImpl implements ReactionMemberValidator {
+
+    private final SubmissionRepository submissionRepository;
+    private final StudyMemberRepository studyMemberRepository;
+
+    @Override
+    public void validate(Long memberId, Long submissionId) {
+        Long studyId = submissionRepository.findStudyIdById(submissionId)
+                .orElseThrow(() -> new ReactionException(ReactionErrorCode.SUBMISSION_NOT_FOUND));
+
+        boolean isStudyMember = studyMemberRepository.existsByStudyIdAndMemberId(studyId, memberId);
+
+        if (!isStudyMember) {
+            throw new ReactionException(ReactionErrorCode.NO_PERMISSION);
+        }
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/api/ReactionControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/ReactionControllerTest.java
@@ -1,0 +1,65 @@
+package econovation.moongtaengi.study.api;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import econovation.moongtaengi.global.config.WebConfig;
+import econovation.moongtaengi.global.security.CustomAuthentication;
+import econovation.moongtaengi.global.security.LoginMemberIdArgumentResolver;
+import econovation.moongtaengi.study.api.dto.ReactionToggleRequest;
+import econovation.moongtaengi.study.application.reaction.ToggleReactionService;
+import econovation.moongtaengi.study.domain.reaction.EmojiType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ReactionController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({WebConfig.class, LoginMemberIdArgumentResolver.class})
+@MockitoBean(types = JpaMetamodelMappingContext.class)
+public class ReactionControllerTest {
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.getContext().setAuthentication(new CustomAuthentication(1L));
+    }
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private ToggleReactionService toggleReactionService;
+
+    @Test
+    @DisplayName("감정표현 토글 요청 시 서비스가 올바르게 호출된다.")
+    void 감정표현_토글_요청_성공() throws Exception {
+        //given
+        Long submissionId = 10L;
+        EmojiType emojiType = EmojiType.HEART;
+        ReactionToggleRequest request = new ReactionToggleRequest(emojiType);
+
+        //when&then
+        mvc.perform(post("/api/submissions/{submissionId}/reactions", submissionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(toggleReactionService).toggleReaction(submissionId, 1L, emojiType);
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/application/ToggleReactionServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/ToggleReactionServiceTest.java
@@ -1,0 +1,85 @@
+package econovation.moongtaengi.study.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import econovation.moongtaengi.study.application.reaction.ToggleReactionService;
+import econovation.moongtaengi.study.domain.reaction.EmojiType;
+import econovation.moongtaengi.study.domain.reaction.Reaction;
+import econovation.moongtaengi.study.domain.reaction.ReactionMemberValidator;
+import econovation.moongtaengi.study.domain.reaction.ReactionRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ToggleReactionServiceTest {
+    @InjectMocks
+    private ToggleReactionService toggleReactionService;
+
+    @Mock
+    private ReactionRepository reactionRepository;
+
+    @Mock
+    private ReactionMemberValidator reactionMemberValidator;
+
+    @Captor
+    private ArgumentCaptor<Reaction> reactionCaptor;
+
+    @Test
+    @DisplayName("기존에 감정표현이 없으면 권한 검사 후 저장한다.")
+    void 기존_감정표현_없음_저장_성공() {
+        //given
+        Long submissionId = 1L;
+        Long memberId = 100L;
+        EmojiType type = EmojiType.HEART;
+
+        given(reactionRepository.findBySubmissionIdAndMemberIdAndEmojiType(submissionId, memberId, type))
+                .willReturn(Optional.empty());
+
+        //when
+        toggleReactionService.toggleReaction(submissionId, memberId, type);
+
+        //then
+        verify(reactionMemberValidator).validate(memberId, submissionId);
+        verify(reactionRepository).save(reactionCaptor.capture());
+
+        Reaction savedReaction = reactionCaptor.getValue();
+        assertThat(savedReaction.getSubmissionId()).isEqualTo(submissionId);
+        assertThat(savedReaction.getMemberId()).isEqualTo(memberId);
+        assertThat(savedReaction.getEmojiType()).isEqualTo(type);
+
+        verify(reactionRepository, never()).delete(any(Reaction.class));
+    }
+
+    @Test
+    @DisplayName("기존에 감정표현이 있으면 권한 검사 후 삭제한다.")
+    void 기존_감정표현_있음() {
+        //given
+        Long submissionId = 1L;
+        Long memberId = 100L;
+        EmojiType type = EmojiType.HEART;
+
+        Reaction existingReaction = Reaction.create(submissionId, memberId, type);
+
+        given(reactionRepository.findBySubmissionIdAndMemberIdAndEmojiType(submissionId, memberId, type))
+                .willReturn(Optional.of(existingReaction));
+
+        //when
+        toggleReactionService.toggleReaction(submissionId, memberId, type);
+
+        //then
+        verify(reactionMemberValidator).validate(memberId, submissionId);
+        verify(reactionRepository).delete(existingReaction);
+        verify(reactionRepository, never()).save(any(Reaction.class));
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/reaction/ReactionTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/reaction/ReactionTest.java
@@ -1,0 +1,49 @@
+package econovation.moongtaengi.study.domain.reaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ReactionTest {
+    @Test
+    @DisplayName("필수 정보(submissionId, memberId, emojiType)가 있으면 생성에 성공한다.")
+    void 감정표현_생성_성공() {
+        //given
+        Long submissionId = 1L;
+        Long userId = 100L;
+        EmojiType type = EmojiType.HEART;
+
+        //when
+        Reaction reaction = Reaction.create(submissionId, userId, type);
+
+        //then
+        assertThat(reaction.getSubmissionId()).isEqualTo(submissionId);
+        assertThat(reaction.getMemberId()).isEqualTo(userId);
+        assertThat(reaction.getEmojiType()).isEqualTo(type);
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}이 누락된 경우 예외 발생")
+    @MethodSource("provideInvalidCreationArguments")
+    @DisplayName("필수 정보(submissionId, userId, emojiType)가 누락되면 생성에 실패한다.")
+    void 감정표현_필수_정보_누락_실패(String expectedMessage, Long submissionId, Long userId, EmojiType emojiType) {
+        //when&then
+        assertThatThrownBy(() -> Reaction.create(submissionId, userId, emojiType))
+                .isInstanceOf(ReactionException.class)
+                .extracting("errorCode")
+                .isEqualTo(ReactionErrorCode.INVALID_REACTION_INFO);
+    }
+
+    private static Stream<Arguments> provideInvalidCreationArguments() {
+        return Stream.of(
+                Arguments.of("submissionId", null, 100L, EmojiType.HEART),
+                Arguments.of("memberId", 1L, null, EmojiType.HEART),
+                Arguments.of("emojiType", 1L, 100L, null)
+        );
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/infra/ReactionMemberValidatorImplTest.java
+++ b/src/test/java/econovation/moongtaengi/study/infra/ReactionMemberValidatorImplTest.java
@@ -1,0 +1,79 @@
+package econovation.moongtaengi.study.infra;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.BDDMockito.given;
+
+import econovation.moongtaengi.study.domain.StudyMemberRepository;
+import econovation.moongtaengi.study.domain.reaction.ReactionErrorCode;
+import econovation.moongtaengi.study.domain.reaction.ReactionException;
+import econovation.moongtaengi.study.domain.submission.SubmissionRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ReactionMemberValidatorImplTest {
+    @InjectMocks
+    private ReactionMemberValidatorImpl validator;
+
+    @Mock
+    private SubmissionRepository submissionRepository;
+
+    @Mock
+    private StudyMemberRepository studyMemberRepository;
+
+    @Test
+    @DisplayName("스터디 멤버라면 제출물에 감정표현을 남길 수 있다.")
+    void 스터디_멤버_감정표현_성공() {
+        //given
+        Long memberId = 1L;
+        Long submissionId = 10L;
+        Long studyId = 100L;
+
+        given(submissionRepository.findStudyIdById(submissionId)).willReturn(Optional.of(studyId));
+        given(studyMemberRepository.existsByStudyIdAndMemberId(studyId, memberId)).willReturn(true);
+
+        //when&then
+        assertDoesNotThrow(() -> validator.validate(memberId, submissionId));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 제출물이라면 예외가 발생한다.")
+    void validate_fail_submission_not_found() {
+        //given
+        Long memberId = 1L;
+        Long submissionId = 999L;
+
+        given(submissionRepository.findStudyIdById(submissionId)).willReturn(Optional.empty());
+
+        //when&then
+        assertThatThrownBy(() -> validator.validate(memberId, submissionId))
+                .isInstanceOf(ReactionException.class)
+                .extracting("errorCode")
+                .isEqualTo(ReactionErrorCode.SUBMISSION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("스터디 멤버가 아니라면 감정표현을 남길 권한이 없다.")
+    void validate_fail_no_permission() {
+        //given
+        Long memberId = 999L;
+        Long submissionId = 10L;
+        Long studyId = 100L;
+
+        given(submissionRepository.findStudyIdById(submissionId)).willReturn(Optional.of(studyId));
+        given(studyMemberRepository.existsByStudyIdAndMemberId(studyId, memberId)).willReturn(false);
+
+        //when&then
+        assertThatThrownBy(() -> validator.validate(memberId, submissionId))
+                .isInstanceOf(ReactionException.class)
+                .extracting("errorCode")
+                .isEqualTo(ReactionErrorCode.NO_PERMISSION);
+    }
+
+}


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
1. 도메인(Domain) 계층
    - 감정표현(Reaction) 엔티티 구현
      - 생성자 접근 제어를 `private`으로 제한하고 정적 팩토리 메서드(`create`)를 도입하여 필수 값 검증 로직 캡슐화
      - `EmojiType` 열거형 정의 (HEART, CLAP, SURPRISED, SAD, EYES_HEART)
      - 데이터 무결성 보장을 위해 DB 레벨의 복합 유니크 키(`submission_id`, `member_id`, `emoji_type`) 제약 조건 설정
    - 도메인 예외 정의
      - `ReactionException` 및 전용 에러 코드(`ReactionErrorCode`)를 정의하여 비즈니스 예외 명세화

2. 도메인 서비스(Domain Service) 및 인프라
    - 권한 검증 로직 분리 (ReactionMemberValidator)
      - 감정표현 생성 전 '제출물 존재 여부'와 '스터디 멤버십 권한'을 검증하는 도메인 서비스 구현
      - 인터페이스와 구현체를 분리하여 도메인 계층의 순수성 유지
    - 애그리게이트 간 결합도 완화
      - 조인 대신 `SubmissionRepository`와 `StudyMemberRepository`를 개별 조회하는 방식 채택
      - 타 도메인(Submission)의 부재 상황을 감정표현 도메인의 문맥에 맞는 에러(`SUBMISSION_NOT_FOUND`)로 치환하여 예외 격리

3. 애플리케이션(Application) 계층
    - 토글 유스케이스 구현 (ToggleReactionService)
      - 단순 생성/삭제가 아닌, 사용자 요청에 따라 상태를 스위칭하는 토글 로직 구현
      - `ReactionMemberValidator`를 주입받아 선행 검증 수행 후, 리포지토리 조회 결과에 따라 `save` 또는 `delete` 분기 처리

4. 표현(Presentation) 계층
    - REST API 구현 (ReactionController)
      - 제출물 하위 리소스로서의 의미를 명확히 하기 위해 `POST /api/submissions/{submissionId}/reactions` 경로 설계
      - `@LoginMemberId` 아규먼트 리졸버를 통해 인증된 사용자 정보 주입

5.  테스트
  - 단위 테스트 
    - ReactionTest
      - `@ParameterizedTest`를 활용하여 필드 누락 검증 및 정상 생성 로직 테스트
    - ReactionMemberValidatorImplTest
      - Mock 객체를 활용하여 성공 케이스 및 예외(제출물 없음, 권한 없음) 매핑 로직 검증
    - ToggleReactionServiceTest
      - `ArgumentCaptor`를 도입하여 `save` 시 생성되는 엔티티의 상태 값이 비즈니스 의도와 일치하는지 정밀 검증
  - 슬라이스 테스트 (ReactionControllerTest)
    - 컨트롤러 계층의 HTTP 요청/응답 스펙과 파라미터 전달 과정 검증
 

### 🧪 테스트 결과
- [x] 테스트 코드 모두 통과하였습니다!!
- [x] 포스트맨을 이용한 테스트
<img width="510" height="376" alt="image" src="https://github.com/user-attachments/assets/cdac9e9e-6493-4146-961c-516bff670b66" />
 
### 👿 트러블 슈팅
- 트러블 슈팅 

  - @WebMvcTest와 JPA Auditing 설정 충돌
    - 문제: 컨트롤러 슬라이스 테스트 실행 시 BeanCreationException: Jpa metamodel must not be empty 에러 발생
    - 원인: @SpringBootApplication에 선언된 @EnableJpaAuditing이 테스트 컨텍스트 로딩 시 함께 실행되려 했으나, @WebMvcTest는 JPA 관련 빈(Entity 등)을 로드하지 않아 의존성 주입 실패
    - 해결: @WebMvcTest 실행 시 발생하는 JPA Metamodel 로딩 에러를 해결하기 위해, 테스트 클래스에 @MockitoBean(types = JpaMetamodelMappingContext.class)를 추가하여 의존성을 임시로 해결함
    - 계획: 메인 애플리케이션 클래스에 선언된 @EnableJpaAuditing을 별도의 Configuration 클래스(JpaAuditingConfig)로 분리할 예정

- 기술적 의사결정
  - Validator의 조회 전략: JOIN vs 개별 Query
    -   고민: ReactionValidator에서 제출물과 멤버십 확인 시 쿼리가 2번 발생하는 것에 대한 성능 우려
    -   결정: 단순 JOIN이 성능상 이점은 있으나, 애그리게이트 간의 물리적 강한 결합(Tight Coupling)을 유발함. 도메인 독립성을 위해 개별 리포지토리 조회(2 Queries) 방식을 채택 (PK 기반 단건 조회이므로 성능 비용 미미하다고 판단)

  - 타 도메인 예외 처리의 격리
    - 고민: Submission 부재 시 SubmissionException을 그대로 전파할지 여부
    - 결정: 외부 도메인의 예외가 현재 도메인(Reaction)을 오염시키지 않도록, ReactionErrorCode.SUBMISSION_NOT_FOUND를 만들어 예외를 내부 문맥으로 바꿔 처리

  - 테스트의 정밀도 향상 (ArgumentCaptor)
    - 고민: verify(repo).save(any()) 사용 시, 구체적으로 어떤 데이터가 저장되는지 검증 불가
    - 결정: ArgumentCaptor를 도입하여 save 메서드에 전달되는 엔티티의 필드 값(submissionId, memberId, emojiType)이 비즈니스 로직 의도대로 생성되었는지 정밀 검증 수행
### 💬 코멘트
이제 과제 승인쪽 할 것 같습니다! 궁금한 점 있으시면 말씀해주세요!! 


