### PR TITLE
feat: 과제 승인(Approve) 기능 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/api/AssignmentController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/AssignmentController.java
@@ -2,6 +2,7 @@ package econovation.moongtaengi.study.api;
 
 import econovation.moongtaengi.global.annotation.LoginMemberId;
 import econovation.moongtaengi.study.api.dto.AssignmentCreateRequest;
+import econovation.moongtaengi.study.application.assignment.ApproveAssignmentService;
 import econovation.moongtaengi.study.application.assignment.AssignmentDetail;
 import econovation.moongtaengi.study.application.assignment.AssignmentQueryService;
 import econovation.moongtaengi.study.application.assignment.AssignmentSummary;
@@ -29,6 +30,7 @@ public class AssignmentController {
 
     private final CreateAssignmentService createAssignmentService;
     private final AssignmentQueryService assignmentQueryService;
+    private final ApproveAssignmentService approveAssignmentService;
 
     @PostMapping
     public ResponseEntity<Void> createAssignment(
@@ -71,5 +73,16 @@ public class AssignmentController {
         AssignmentDetail response = assignmentQueryService.getAssignmentDetail(memberId, assignmentId);
 
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{assignmentId}/approve")
+    public ResponseEntity<Void> approveAssignment(
+            @LoginMemberId Long memberId,
+            @PathVariable Long assignmentId
+    ) {
+        log.info("과제 승인 API 호출 - requesterId: {}, assignmentId: {}", memberId, assignmentId);
+
+        approveAssignmentService.approveAssignment(assignmentId, memberId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/ApproveAssignmentService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/ApproveAssignmentService.java
@@ -1,0 +1,36 @@
+package econovation.moongtaengi.study.application.assignment;
+
+import econovation.moongtaengi.study.domain.assignment.*;
+import econovation.moongtaengi.study.domain.assignment.ProcessInfoProvider.ProcessInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApproveAssignmentService {
+
+    private final AssignmentRepository assignmentRepository;
+    private final AssignmentManagementPolicy assignmentManagementPolicy;
+    private final ProcessInfoProvider processInfoProvider;
+
+    @Transactional
+    public void approveAssignment(Long assignmentId, Long requesterId) {
+        Assignment assignment = assignmentRepository.findById(assignmentId)
+                .orElseThrow(() -> new AssignmentException(AssignmentErrorCode.ASSIGNMENT_NOT_FOUND));
+
+        ProcessInfo processInfo = processInfoProvider.getProcessInfo(assignment.getProcessId());
+
+        assignmentManagementPolicy.validate(processInfo.studyId(), requesterId);
+
+        assignment.approve();
+
+        log.info("과제 승인 성공 - assignmentId: {}, requesterId: {}, studyId: {}",
+                assignmentId,
+                requesterId,
+                processInfo.studyId()
+        );
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/Assignment.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/Assignment.java
@@ -57,6 +57,13 @@ public class Assignment extends BaseEntity {
         this.isLate = isLate;
     }
 
+    public void approve() {
+        if (this.status != AssignmentStatus.SUBMITTED) {
+            throw new AssignmentException(AssignmentErrorCode.CANNOT_APPROVE_NOT_SUBMITTED);
+        }
+        this.status = AssignmentStatus.APPROVED;
+    }
+
     private static void validate(Long processId, Long assigneeId, AssignmentContent content, AssignmentDeadline deadline) {
         if (processId == null || assigneeId == null || content == null || deadline == null) {
             throw new AssignmentException(AssignmentErrorCode.INVALID_ASSIGNMENT_INFO);

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentErrorCode.java
@@ -16,7 +16,9 @@ public enum AssignmentErrorCode implements ErrorCode {
 
     INVALID_PROCESS_ID(HttpStatus.BAD_REQUEST, "AS_004","유효하지 않은 프로세스 ID 입니다."),
 
-    ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "AS_005", "존재하지 않는 과제입니다.");
+    ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "AS_005", "존재하지 않는 과제입니다."),
+
+    CANNOT_APPROVE_NOT_SUBMITTED(HttpStatus.BAD_REQUEST, "AS_006", "제출되지 않은 과제는 승인할 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionErrorCode.java
@@ -8,9 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ReactionErrorCode implements ErrorCode {
-    INVALID_REACTION_INFO(HttpStatus.BAD_REQUEST, "RT_001", "감정표현의 필수 정보가 누락되었습니다."),
-    SUBMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "RT_002", "존재하지 않는 제출물입니다."),
-    NO_PERMISSION(HttpStatus.FORBIDDEN, "RT_003", "감정표현을 할 권한이 없습니다.");
+    INVALID_REACTION_INFO(HttpStatus.BAD_REQUEST, "RT_001", "감정표현의 필수 정보가 누락되었습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ReactionErrorCode implements ErrorCode {
-    INVALID_REACTION_INFO(HttpStatus.BAD_REQUEST, "RT_001", "감정표현의 필수 정보가 누락되었습니다.");
+    INVALID_REACTION_INFO(HttpStatus.BAD_REQUEST, "RT_001", "감정표현의 필수 정보가 누락되었습니다."),
+    SUBMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "RT_002", "존재하지 않는 제출물입니다."),
+    NO_PERMISSION(HttpStatus.FORBIDDEN, "RT_003", "감정표현을 할 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/test/java/econovation/moongtaengi/study/api/AssignmentControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/AssignmentControllerTest.java
@@ -11,6 +11,7 @@ import econovation.moongtaengi.global.config.WebConfig;
 import econovation.moongtaengi.global.security.CustomAuthentication;
 import econovation.moongtaengi.global.security.LoginMemberIdArgumentResolver;
 import econovation.moongtaengi.study.api.dto.AssignmentCreateRequest;
+import econovation.moongtaengi.study.application.assignment.ApproveAssignmentService;
 import econovation.moongtaengi.study.application.assignment.AssignmentDetail;
 import econovation.moongtaengi.study.application.assignment.AssignmentQueryService;
 import econovation.moongtaengi.study.application.assignment.AssignmentSummary;
@@ -66,6 +67,9 @@ public class AssignmentControllerTest {
 
     @MockitoBean
     private AssignmentQueryService assignmentQueryService;
+
+    @MockitoBean
+    private ApproveAssignmentService approveAssignmentService;
 
     @BeforeEach
     void setUp() {
@@ -280,5 +284,21 @@ public class AssignmentControllerTest {
         mvc.perform(get("/api/assignments/{assignmentId}", assignmentId))
                 .andDo(print())
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("과제 승인 요청 시 서비스를 호출하고 200 OK를 반환한다")
+    void 과제_승인_성공() throws Exception {
+        //given
+        Long assignmentId = 100L;
+        Long requesterId = 1L;
+
+        //when&then
+        mvc.perform(post("/api/assignments/{assignmentId}/approve", assignmentId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(approveAssignmentService).approveAssignment(assignmentId, requesterId);
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/application/ApproveAssignmentServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/ApproveAssignmentServiceTest.java
@@ -2,11 +2,15 @@ package econovation.moongtaengi.study.application;
 
 import static econovation.moongtaengi.study.domain.assignment.AssignmentFixture.anAssignment;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 
 import econovation.moongtaengi.study.application.assignment.ApproveAssignmentService;
 import econovation.moongtaengi.study.domain.assignment.Assignment;
+import econovation.moongtaengi.study.domain.assignment.AssignmentErrorCode;
+import econovation.moongtaengi.study.domain.assignment.AssignmentException;
 import econovation.moongtaengi.study.domain.assignment.AssignmentManagementPolicy;
 import econovation.moongtaengi.study.domain.assignment.AssignmentRepository;
 import econovation.moongtaengi.study.domain.assignment.AssignmentStatus;
@@ -63,5 +67,51 @@ public class ApproveAssignmentServiceTest {
         assertThat(assignment.getStatus()).isEqualTo(AssignmentStatus.APPROVED);
 
         verify(assignmentManagementPolicy).validate(studyId, requesterId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 과제 ID로 승인 요청 시 예외가 발생한다.")
+    void 과제_승인_실패_과제없음() {
+        //given
+        Long invalidAssignmentId = 999L;
+        Long requesterId = 1L;
+
+        given(assignmentRepository.findById(invalidAssignmentId))
+                .willReturn(Optional.empty());
+
+        //when&then
+        assertThatThrownBy(() -> approveAssignmentService.approveAssignment(invalidAssignmentId, requesterId))
+                .isInstanceOf(AssignmentException.class)
+                .extracting("errorCode")
+                .isEqualTo(AssignmentErrorCode.ASSIGNMENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("과제 관리자 권한이 없는 경우 검증기에서 예외를 던진다.")
+    void 과제_승인_실패_권한없음() {
+        //given
+        Long assignmentId = 100L;
+        Long requesterId = 2L;
+        Long processId = 10L;
+        Long studyId = 99L;
+
+        Assignment assignment = anAssignment()
+                .processId(processId)
+                .build();
+
+        given(assignmentRepository.findById(assignmentId))
+                .willReturn(Optional.of(assignment));
+
+        given(processInfoProvider.getProcessInfo(processId))
+                .willReturn(new ProcessInfo(studyId, LocalDate.now(), LocalDate.now()));
+
+        willThrow(new AssignmentException(AssignmentErrorCode.NO_MANAGEMENT_PERMISSION))
+                .given(assignmentManagementPolicy).validate(studyId, requesterId);
+
+        //when&then
+        assertThatThrownBy(() -> approveAssignmentService.approveAssignment(assignmentId, requesterId))
+                .isInstanceOf(AssignmentException.class)
+                .extracting("errorCode")
+                .isEqualTo(AssignmentErrorCode.NO_MANAGEMENT_PERMISSION);
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/application/ApproveAssignmentServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/ApproveAssignmentServiceTest.java
@@ -1,0 +1,67 @@
+package econovation.moongtaengi.study.application;
+
+import static econovation.moongtaengi.study.domain.assignment.AssignmentFixture.anAssignment;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import econovation.moongtaengi.study.application.assignment.ApproveAssignmentService;
+import econovation.moongtaengi.study.domain.assignment.Assignment;
+import econovation.moongtaengi.study.domain.assignment.AssignmentManagementPolicy;
+import econovation.moongtaengi.study.domain.assignment.AssignmentRepository;
+import econovation.moongtaengi.study.domain.assignment.AssignmentStatus;
+import econovation.moongtaengi.study.domain.assignment.ProcessInfoProvider;
+import econovation.moongtaengi.study.domain.assignment.ProcessInfoProvider.ProcessInfo;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ApproveAssignmentServiceTest {
+
+    @InjectMocks
+    private ApproveAssignmentService approveAssignmentService;
+
+    @Mock
+    private AssignmentRepository assignmentRepository;
+
+    @Mock
+    private AssignmentManagementPolicy assignmentManagementPolicy;
+
+    @Mock
+    private ProcessInfoProvider processInfoProvider;
+
+    @Test
+    @DisplayName("과제 승인할 때 관리자 권한이 확인되면 과제 상태가 APPROVED로 변경된다.")
+    void 과제_승인_성공() {
+        // given
+        Long requesterId = 1L;
+        Long studyId = 99L;
+        Long processId = 10L;
+        Long assignmentId = 100L;
+
+        Assignment assignment = anAssignment()
+                .processId(processId)
+                .build();
+        assignment.markAsSubmitted(false);
+
+        given(assignmentRepository.findById(assignmentId))
+                .willReturn(Optional.of(assignment));
+
+        given(processInfoProvider.getProcessInfo(processId))
+                .willReturn(new ProcessInfo(studyId, LocalDate.now(), LocalDate.now()));
+
+        //when
+        approveAssignmentService.approveAssignment(assignmentId, requesterId);
+
+        //then
+        assertThat(assignment.getStatus()).isEqualTo(AssignmentStatus.APPROVED);
+
+        verify(assignmentManagementPolicy).validate(studyId, requesterId);
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentTest.java
@@ -2,6 +2,7 @@ package econovation.moongtaengi.study.domain.assignment;
 
 import static econovation.moongtaengi.study.domain.assignment.AssignmentFixture.anAssignment;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,5 +50,32 @@ public class AssignmentTest {
         //then
         assertThat(assignment.getStatus()).isEqualTo(AssignmentStatus.SUBMITTED);
         assertThat(assignment.isLate()).isTrue();
+    }
+
+    @Test
+    @DisplayName("제출된 과제는 승인 상태로 변경할 수 있다.")
+    void 과제_승인_성공() {
+        //given
+        Assignment assignment = anAssignment().build();
+        assignment.markAsSubmitted(false);
+
+        //when
+        assignment.approve();
+
+        //then
+        assertThat(assignment.getStatus()).isEqualTo(AssignmentStatus.APPROVED);
+    }
+
+    @Test
+    @DisplayName("제출되지 않은 과제는 승인할 수 없다.")
+    void 과제_승인_미제출_상태_실패() {
+        //given
+        Assignment assignment = anAssignment().build();
+
+        //when&then
+        assertThatThrownBy(() -> assignment.approve())
+                .isInstanceOf(AssignmentException.class)
+                .extracting("errorCode")
+                .isEqualTo(AssignmentErrorCode.CANNOT_APPROVE_NOT_SUBMITTED);
     }
 }


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
- Domain Layer
   - `Assignment` 엔티티에 상태 변경 로직인 `approve()` 메서드 추가
   - 비즈니스 불변식 검증: `SUBMITTED` 상태가 아닌 과제는 승인 불가 (`CANNOT_APPROVE_NOT_SUBMITTED` 예외 처리)
   - `AssignmentTest`: 도메인 객체의 상태 변경 및 예외 발생에 대한 단위 테스트 작성 완료
- Application Layer
   - `ApproveAssignmentService` 구현: 과제 승인 유스케이스 담당
   - `ProcessInfoProvider`와 `AssignmentManagementPolicy` 인터페이스를 활용해 강한 결합 없이 스터디 정보 조회 및 권한 검증 수행
   - 트랜잭션 관리: Dirty Checking을 활용하여 명시적 `save` 호출 없이 상태 변경 반영
   - `ApproveAssignmentServiceTest`: 정상 승인 로직뿐만 아니라 예외 케이스(존재하지 않는 과제, 권한 없음)에 대한 Mockito 기반 테스트 작성 완료
- Presentation Layer
   - `AssignmentController`: `POST /api/assignments/{id}/approve` 엔드포인트 구현
   - `AssignmentControllerTest`: `@WebMvcTest`를 사용하여 HTTP 요청 매핑, 응답 상태(200 OK), 서비스 위임 여부 검증 완료
### 🧪 테스트 결과
- [x] 테스트 코드 모두 통과했습니다!!
- [x] 포스트맨을 이용한 테스트
<img width="644" height="496" alt="image" src="https://github.com/user-attachments/assets/5b92e8a8-2097-41c9-87df-b71c3acad1f3" />
 
### 👿 트러블 슈팅
Git 브랜치 전략 미준수 및 복구
- 상황: 이전 기능(Reaction) 구현 브랜치에서 브랜치 변경을 누락하고 Assignment 승인 기능 개발을 진행하여 커밋이 혼재되는 상황 발생.

- 문제: 서로 다른 도메인의 변경 사항이 하나의 브랜치에 섞여, PR의 단위가 커지고 코드 리뷰의 복잡도가 증가
- 해결:
  - 현재 작업 내용(Commit History)을 유지한 채 새로운 브랜치(feat/assignmentApprove)로 분기 (git switch -c)
  - 기존 브랜치는 git reset --hard를 사용하여 작업 시작 전 시점으로 롤백

### 💬 코멘트
오늘은 조회 쪽 달려보겠습니다! 궁금한 점 있으시면 말씀해주세요!


