### PR TITLE
refactor: Submission 첨부파일 구조 변경 (List -> Single Embedded) 및 API 명세 수정

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/api/dto/SubmissionCreateRequest.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/SubmissionCreateRequest.java
@@ -12,14 +12,16 @@ public record SubmissionCreateRequest(
         @NotBlank
         String content,
 
-        List<String> attachmentUrls
+        String fileName,
+        String fileUrl
 ) {
     public CreateSubmissionCommand toCommand(Long submitterId) {
         return new CreateSubmissionCommand(
                 assignmentId,
                 submitterId,
                 content,
-                attachmentUrls
+                fileName,
+                fileUrl
         );
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentSummary.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentSummary.java
@@ -10,6 +10,7 @@ public record AssignmentSummary(
         String nickname,
         AssignmentStatus status,
         Boolean isLate,
+        String fileName,
         String fileUrl
 ) {
 

--- a/src/main/java/econovation/moongtaengi/study/application/submission/CreateSubmissionCommand.java
+++ b/src/main/java/econovation/moongtaengi/study/application/submission/CreateSubmissionCommand.java
@@ -1,17 +1,15 @@
 package econovation.moongtaengi.study.application.submission;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.springframework.util.StringUtils;
 
 public record CreateSubmissionCommand(
         Long assignmentId,
         Long submitterId,
         String content,
-        List<String> attachmentUrls
+        String fileName,
+        String fileUrl
 ) {
-    public CreateSubmissionCommand {
-        if (attachmentUrls == null) {
-            attachmentUrls = new ArrayList<>();
-        }
+    public boolean hasAttachment() {
+        return StringUtils.hasText(fileName) && StringUtils.hasText(fileUrl);
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/application/submission/CreateSubmissionService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/submission/CreateSubmissionService.java
@@ -34,16 +34,17 @@ public class CreateSubmissionService {
 
         SubmissionContent content = new SubmissionContent(command.content());
 
-        List<SubmissionAttachment> attachments = command.attachmentUrls().stream()
-                .map(SubmissionAttachment::new)
-                .toList();
+        SubmissionAttachment attachment = null;
+        if (command.hasAttachment()) {
+            attachment = SubmissionAttachment.of(command.fileName(), command.fileUrl());
+        }
 
         Submission submission = Submission.builder()
                 .assignmentId(command.assignmentId())
                 .submitterId(command.submitterId())
                 .content(content)
                 .currentDateTime(LocalDateTime.now())
-                .attachments(attachments)
+                .attachment(attachment)
                 .assignmentDeadline(assignmentInfo.deadline())
                 .build();
 

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepository.java
@@ -21,13 +21,13 @@ public interface AssignmentRepository extends JpaRepository<Assignment, Long> {
             m.nickname.value,
             a.status,
             a.isLate,
-            sa.url
+            s.attachment.name,
+            s.attachment.url
         )
         FROM StudyMember sm
         JOIN Member m ON sm.memberId = m.id
         LEFT JOIN Assignment a ON a.assigneeId = m.id AND a.processId = :processId
         LEFT JOIN Submission s ON s.assignmentId = a.id AND s.submitterId = m.id
-        LEFT JOIN s.attachments sa
         WHERE sm.study.id = :studyId
     """)
     List<AssignmentSummary> findSummaryByProcessIdAndStudyId(

--- a/src/main/java/econovation/moongtaengi/study/domain/submission/Submission.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/submission/Submission.java
@@ -2,6 +2,7 @@ package econovation.moongtaengi.study.domain.submission;
 
 import econovation.moongtaengi.global.entity.BaseEntity;
 import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -12,6 +13,7 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,7 +26,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Submission extends BaseEntity {
-    private static final int MAX_ATTACHMENTS_SIZE = 1;
 
     @Column(name = "assignment_id", nullable = false)
     private Long assignmentId;
@@ -35,16 +36,13 @@ public class Submission extends BaseEntity {
     @Embedded
     private SubmissionContent content;
 
-    @ElementCollection
-    @CollectionTable(
-            name = "submission_attachments",
-            joinColumns = @JoinColumn(name = "submission_id")
-    )
-    @AttributeOverride(
-            name = "url",
-            column = @Column(name = "file_url", nullable = false)
-    )
-    private List<SubmissionAttachment> attachments = new ArrayList<>();
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "name", column = @Column(name = "file_name", nullable = true)),
+            @AttributeOverride(name = "url", column = @Column(name = "file_url", nullable = true))
+    })
+    @Getter(AccessLevel.NONE)
+    private SubmissionAttachment attachment;
 
     @Column(name = "is_late", nullable = false)
     private boolean isLate;
@@ -56,32 +54,27 @@ public class Submission extends BaseEntity {
             SubmissionContent content,
             LocalDateTime currentDateTime,
             LocalDateTime assignmentDeadline,
-            List<SubmissionAttachment> attachments) {
-        validate(assignmentId, submitterId, content, currentDateTime, assignmentDeadline, attachments);
+            SubmissionAttachment attachment) {
+        validate(assignmentId, submitterId, content, currentDateTime, assignmentDeadline);
 
         boolean isLate = currentDateTime.isAfter(assignmentDeadline);
 
-        List<SubmissionAttachment> safeAttachments = (attachments != null)
-                ? new ArrayList<>(attachments)
-                : new ArrayList<>();
-
-        Submission submission = new Submission(assignmentId, submitterId, content, safeAttachments, isLate);
+        Submission submission = new Submission(assignmentId, submitterId, content, attachment, isLate);
 
         submission.registerEvent(new SubmissionCreatedEvent(assignmentId, submitterId, isLate));
 
         return submission;
     }
 
+    public Optional<SubmissionAttachment> getAttachment() {
+        return Optional.ofNullable(attachment);
+    }
+
     private static void validate(Long assignmentId, Long submitterId, SubmissionContent content,
-            LocalDateTime currentDateTime, LocalDateTime assignmentDeadline,
-            List<SubmissionAttachment> attachments) {
+            LocalDateTime currentDateTime, LocalDateTime assignmentDeadline) {
         if (assignmentId == null || submitterId == null || content == null ||
                 currentDateTime == null || assignmentDeadline == null) {
             throw new SubmissionException(SubmissionErrorCode.CREATE_ARGUMENT_MISSING);
-        }
-
-        if (attachments != null && attachments.size() > 1) {
-            throw new SubmissionException(SubmissionErrorCode.ATTACHMENT_LIMIT_EXCEEDED, MAX_ATTACHMENTS_SIZE);
         }
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/domain/submission/SubmissionAttachment.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/submission/SubmissionAttachment.java
@@ -16,15 +16,28 @@ public class SubmissionAttachment {
     private static final String URL_REGEX = "^https?://\\S+$";
     private static final Pattern URL_PATTERN = Pattern.compile(URL_REGEX);
 
+    @Column(name = "file_name", nullable = false)
+    private String name;
+
     @Column(name = "file_url", nullable = false)
     private String url;
 
-    public SubmissionAttachment(String url) {
-        validate(url);
+    private SubmissionAttachment(String name, String url) {
+        validate(name, url);
+        this.name = name;
         this.url = url;
     }
 
-    private void validate(String url) {
+    public static SubmissionAttachment of(String name, String url) {
+        return new SubmissionAttachment(name, url);
+    }
+
+    private void validate(String name, String url) {
+        if (name == null || name.isBlank()) {
+            throw new SubmissionException(SubmissionErrorCode.INVALID_SUBMISSION_INFO);
+        }
+
+
         if (url == null || url.isBlank()) {
             throw new SubmissionException(SubmissionErrorCode.INVALID_ATTACHMENT_URL);
         }

--- a/src/test/java/econovation/moongtaengi/study/api/AssignmentControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/AssignmentControllerTest.java
@@ -189,6 +189,7 @@ public class AssignmentControllerTest {
                         "알고리즘 과제",
                         "지환", AssignmentStatus.SUBMITTED,
                         false,
+                        "파일명.pdf",
                         "http://file.url"),
                 new AssignmentSummary(11L,
                         null,
@@ -197,6 +198,7 @@ public class AssignmentControllerTest {
                         "철수",
                         AssignmentStatus.WAITING,
                         true,
+                        null,
                         null)
         );
 

--- a/src/test/java/econovation/moongtaengi/study/api/SubmissionControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/SubmissionControllerTest.java
@@ -62,7 +62,8 @@ public class SubmissionControllerTest {
         SubmissionCreateRequest request = new SubmissionCreateRequest(
                 1L,
                 "테스트 제출물",
-                List.of("http://image.url")
+                "과제.pdf",
+                "http://image.url"
         );
 
         given(createSubmissionService.createSubmission(any(CreateSubmissionCommand.class)))
@@ -84,7 +85,7 @@ public class SubmissionControllerTest {
         assertThat(passedCommand.submitterId()).isEqualTo(1L);
         assertThat(passedCommand.assignmentId()).isEqualTo(request.assignmentId());
         assertThat(passedCommand.content()).isEqualTo(request.content());
-        assertThat(passedCommand.attachmentUrls()).hasSize(1);
+        //assertThat(passedCommand.attachment).hasSize(1);
     }
 
     @DisplayName("필수값이 누락되거나 유효하지 않은 경우 400 Bad Request를 반환한다")
@@ -95,7 +96,8 @@ public class SubmissionControllerTest {
         SubmissionCreateRequest badRequest = new SubmissionCreateRequest(
                 assignmentId,
                 content,
-                List.of()
+                null,
+                null
         );
 
         //when&then

--- a/src/test/java/econovation/moongtaengi/study/application/CreateSubmissionServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/CreateSubmissionServiceTest.java
@@ -47,7 +47,8 @@ public class CreateSubmissionServiceTest {
                 DEFAULT_ASSIGNMENT_ID,
                 DEFAULT_SUBMITTER_ID,
                 DEFAULT_CONTENT.getValue(),
-                Collections.emptyList()
+                DEFAULT_ATTACHMENT.getName(),
+                DEFAULT_ATTACHMENT.getUrl()
         );
 
         Submission savedSubmission = aSubmission().build();
@@ -71,8 +72,13 @@ public class CreateSubmissionServiceTest {
         ArgumentCaptor<Submission> captor = ArgumentCaptor.forClass(Submission.class);
         verify(submissionRepository).save(captor.capture());
 
-        assertThat(captor.getValue().getAssignmentId()).isEqualTo(DEFAULT_ASSIGNMENT_ID);
-        assertThat(captor.getValue().getSubmitterId()).isEqualTo(DEFAULT_SUBMITTER_ID);
-        assertThat(captor.getValue().getContent().getValue()).isEqualTo(DEFAULT_CONTENT.getValue());
+        Submission capturedSubmission = captor.getValue();
+
+        assertThat(capturedSubmission.getAssignmentId()).isEqualTo(DEFAULT_ASSIGNMENT_ID);
+        assertThat(capturedSubmission.getContent().getValue()).isEqualTo(DEFAULT_CONTENT.getValue());
+
+        assertThat(capturedSubmission.getAttachment()).isPresent();
+        assertThat(capturedSubmission.getAttachment().get().getName()).isEqualTo(DEFAULT_ATTACHMENT.getName());
+        assertThat(capturedSubmission.getAttachment().get().getUrl()).isEqualTo(DEFAULT_ATTACHMENT.getUrl());
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepositoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepositoryTest.java
@@ -72,7 +72,7 @@ public class AssignmentRepositoryTest {
         em.persistAndFlush(SubmissionFixture.aSubmission()
                 .assignmentId(assignment1.getId())
                 .submitterId(host.getId())
-                .attachments(List.of(new SubmissionAttachment("http://url.com")))
+                .attachment(SubmissionAttachment.of("파일명.pdf", "http://url.com"))
                 .build());
 
         assignment1.markAsSubmitted(false);
@@ -93,6 +93,7 @@ public class AssignmentRepositoryTest {
         assertThat(dto1.status()).isEqualTo(AssignmentStatus.SUBMITTED);
         assertThat(dto1.submissionId()).isNotNull();
         assertThat(dto1.memberId()).isEqualTo(host.getId());
+        assertThat(dto1.fileName()).isEqualTo("파일명.pdf");
         assertThat(dto1.fileUrl()).isEqualTo("http://url.com");
 
         AssignmentSummary dto2 = result.stream()

--- a/src/test/java/econovation/moongtaengi/study/domain/submission/SubmissionFixture.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/submission/SubmissionFixture.java
@@ -10,13 +10,14 @@ public class SubmissionFixture {
     public static final Long DEFAULT_SUBMITTER_ID = 1L;
     public static final SubmissionContent DEFAULT_CONTENT = new SubmissionContent("제출 완료");
     public static final LocalDateTime BASE_TIME = StudyFixture.FIXED_DATE.atStartOfDay();
+    public static final SubmissionAttachment DEFAULT_ATTACHMENT = SubmissionAttachment.of("파일명", "http://url.com");
 
     public static Submission.SubmissionBuilder aSubmission() {
         return Submission.builder()
                 .assignmentId(DEFAULT_ASSIGNMENT_ID)
                 .submitterId(DEFAULT_SUBMITTER_ID)
                 .content(DEFAULT_CONTENT)
-                .attachments(new ArrayList<>())
+                .attachment(DEFAULT_ATTACHMENT)
                 .currentDateTime(BASE_TIME.plusDays(1))
                 .assignmentDeadline(BASE_TIME.plusDays(7));
     }

--- a/src/test/java/econovation/moongtaengi/study/domain/submission/SubmissionTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/submission/SubmissionTest.java
@@ -16,13 +16,34 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public class SubmissionTest {
     @Test
-    @DisplayName("모든 필수 값이 정상일 때 Submission이 생성된다")
-    void 제출물_생성_성공() {
-        //given&when
-        Submission submission = aSubmission().build();
+    @DisplayName("첨부파일이 포함된 Submission이 정상 생성되고, Optional로 조회된다")
+    void 제출물_생성_성공_첨부파일_있음() {
+        //given
+        SubmissionAttachment attachment = SubmissionAttachment.of("과제.pdf", "https://url.com");
+
+        //when
+        Submission submission = aSubmission()
+                .attachment(attachment)
+                .build();
 
         //then
         assertThat(submission).isNotNull();
+        assertThat(submission.getAttachment()).isPresent();
+        assertThat(submission.getAttachment().get().getName()).isEqualTo("과제.pdf");
+        assertThat(submission.isLate()).isFalse();
+    }
+
+    @Test
+    @DisplayName("첨부파일이 없는 Submission도 정상 생성되며, 빈 Optional이 조회된다")
+    void 제출물_생성_성공_첨부파일_없음() {
+        //given&when
+        Submission submission = aSubmission()
+                .attachment(null)
+                .build();
+
+        //then
+        assertThat(submission).isNotNull();
+        assertThat(submission.getAttachment()).isEmpty();
         assertThat(submission.isLate()).isFalse();
     }
 
@@ -47,23 +68,6 @@ public class SubmissionTest {
         );
     }
 
-    @Test
-    @DisplayName("첨부파일이 2개 이상이면 예외가 발생한다")
-    void 첨부파일_2개_이상_실패() {
-        //given
-        List<SubmissionAttachment> twoAttachments = List.of(
-                new SubmissionAttachment("http://url1"),
-                new SubmissionAttachment("http://url2")
-        );
-
-        //when&then
-        assertThatThrownBy(() -> aSubmission()
-                .attachments(twoAttachments)
-                .build())
-                .isInstanceOf(SubmissionException.class)
-                .extracting("errorCode")
-                .isEqualTo(SubmissionErrorCode.ATTACHMENT_LIMIT_EXCEEDED);
-    }
 
     @Test
     @DisplayName("마감 기한을 넘기면 '지각' 상태가 되고 이벤트가 발행된다")

--- a/src/test/java/econovation/moongtaengi/study/domain/submission/SubmissionVOTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/submission/SubmissionVOTest.java
@@ -60,10 +60,11 @@ public class SubmissionVOTest {
         @DisplayName("정상적인 URL로 첨부파일을 생성한다")
         void 첨부파일_생성_성공() {
             //given
+            String fileName = "파일명";
             String validUrl = "https://example.com/file.pdf";
 
             //when
-            SubmissionAttachment attachment = new SubmissionAttachment(validUrl);
+            SubmissionAttachment attachment = SubmissionAttachment.of(fileName, validUrl);
 
             //then
             assertThat(attachment.getUrl()).isEqualTo(validUrl);
@@ -74,7 +75,7 @@ public class SubmissionVOTest {
         @DisplayName("URL이 없으면 예외가 발생한다")
         void 첨부파일_URL_없음_실패(String invalidUrl) {
             //when&then
-            assertThatThrownBy(() -> new SubmissionAttachment(invalidUrl))
+            assertThatThrownBy(() -> SubmissionAttachment.of("파일명", invalidUrl))
                     .isInstanceOf(SubmissionException.class)
                     .extracting("errorCode")
                     .isEqualTo(SubmissionErrorCode.INVALID_ATTACHMENT_URL);
@@ -85,7 +86,7 @@ public class SubmissionVOTest {
         @DisplayName("URL 형식이 올바르지 않으면 예외가 발생한다")
         void 첨부파일_URL_형식_실패(String invalidUrl) {
             //when&then
-            assertThatThrownBy(() -> new SubmissionAttachment(invalidUrl))
+            assertThatThrownBy(() -> SubmissionAttachment.of("파일명", invalidUrl))
                     .isInstanceOf(SubmissionException.class)
                     .extracting("errorCode")
                     .isEqualTo(SubmissionErrorCode.INVALID_ATTACHMENT_URL);


### PR DESCRIPTION
### 📌 PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
**배경**
기존 `Submission` 도메인은 첨부파일을 `@ElementCollection`을 사용하여 1:N(`List`) 관계로 관리. 
하지만 기획상 과제당 첨부파일은 최대 1개라는 제약 조건이 확정됨. 
오히려 nullable을 피할 수 있다는 장점이 있다고 생각했지만 불필요한 테이블 조인과 컬렉션 관리 비용을 줄이기 위해 구조를 변경.

1. Domain & DB 최적화
- Submission Entity: `List<SubmissionAttachment>`를 제거하고, 단일 객체인 `SubmissionAttachment`를 `@Embedded`로 적용.
- Schema: 별도의 `submission_attachments` 테이블을 삭제하고, `submissions` 테이블 내의 `file_name`, `file_url` 컬럼으로 역정규화.
- Repository: 불필요한 `LEFT JOIN` 쿼리를 제거하고, Embedded 필드 접근 방식(`s.attachment.url`)으로 JPQL을 수정

2. API 명세 변경
API 요청 및 응답에서 다중 파일(`List`) 지원 필드가 제거되고, 단일 파일 필드로 변경되었습니다.
[Request] `POST /api/submissions`
- (변경 전) `attachmentUrls: List<String>`
- (변경 후) `fileName: String`, `fileUrl: String` (Nullable)

[Response] 과제 조회 관련 DTO
- (변경 전) `fileUrls: List<String>`
- (변경 후) `fileName: String`, `fileUrl: String`

3. Service & Test Refactoring
- `CreateSubmissionService`: 리스트 처리 로직을 제거하고 단일 객체 생성 로직으로 변경했습니다.
- Test Code: `SubmissionTest`, `AssignmentRepositoryTest`, `SubmissionControllerTest` 등 깨지는 모든 테스트를 수정하고, 새로운 구조에 맞춰 테스트 케이스를 보강.


### 🧪 테스트 결과
- [x] `SubmissionVOTest` 통과 (VO 검증)
- [x] `SubmissionTest` 통과 (Entity 로직 및 이벤트 발행)
- [x] `CreateSubmissionServiceTest` 통과 (서비스 로직)
- [x] `AssignmentRepositoryTest` 통과 (JPA 쿼리 검증)
- [x] `SubmissionControllerTest` 통과 (API 계층 검증)
- [x] 추가적으로 나머지 테스트 코드 모두 통과 
- [x] 포스트맨과 h2-console을 이용한 테스트
<img width="258" height="200" alt="image" src="https://github.com/user-attachments/assets/d2a75df4-2699-4da2-ada6-4be5f4b64687" />
<img width="664" height="64" alt="image" src="https://github.com/user-attachments/assets/00cef2d5-031b-4537-8cc6-c555af174fb4" />
 
### 👿 트러블 슈팅
@AttributeOverride 사용 시 컬럼명 초기화 문제

**1. 문제 **
- `Submission` 엔티티에서 `SubmissionAttachment` VO의 `nullable` 속성만 변경하기 위해 `@AttributeOverride`를 적용함.
- 예상: VO에 정의된 컬럼명(`file_name`)은 유지되고, `nullable`만 `true`로 바뀔 것.
- 실제: DB 스키마 확인 결과, 컬럼명이 `file_name`이 아닌 VO의 필드명(`name`)으로 생성됨. (DB 에러는 발생하지 않음)

**2. 원인**
- `@AttributeOverride`는 기존 VO의 `@Column` 설정을 부분 수정(Merge)하는 것이 아니라, 완전히 대체(Replace)하는 방식으로 동작함.
- 재정의하는 `@Column` 안에 `name` 속성을 명시하지 않았기 때문에, 기존의 `name="file_name"` 설정이 날아가고 JPA 기본 네이밍 전략(필드명 `name`)이 적용됨.

**3. 해결 **
- `@AttributeOverride`를 사용할 때는 변경하려는 속성뿐만 아니라, **유지해야 할 속성(컬럼명 등)도 모두 명시**해야 함.

```java
// [Before] 기존 컬럼명("file_name") 설정이 날아감
@AttributeOverride(name = "name", column = @Column(nullable = true))

// [After] 컬럼명까지 다시 명시해줘야 함
@AttributeOverride(name = "name", column = @Column(name = "file_name", nullable = true))





### 💬 코멘트



