### PR TITLE
feat: 감정 표현에 따른 퀘스트, 컬렉션 발급 구현 및 댓글 갯수에 따른 컬렉션 발급 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/collection/application/CollectionEventListener.java
+++ b/src/main/java/econovation/moongtaengi/collection/application/CollectionEventListener.java
@@ -7,7 +7,11 @@ import econovation.moongtaengi.member.domain.event.MemberRegisteredEvent;
 import econovation.moongtaengi.onboarding.domain.event.OnboardingMissionCompletedEvent;
 import econovation.moongtaengi.study.domain.Study;
 import econovation.moongtaengi.study.domain.StudyRepository;
+import econovation.moongtaengi.study.domain.comment.CommentCreatedEvent;
+import econovation.moongtaengi.study.domain.comment.CommentRepository;
 import econovation.moongtaengi.study.domain.event.StudyJoinedEvent;
+import econovation.moongtaengi.study.domain.reaction.ReactionAddedEvent;
+import econovation.moongtaengi.study.domain.reaction.ReactionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -27,6 +31,8 @@ public class CollectionEventListener {
 
     private final CollectionService collectionService;
     private final StudyRepository studyRepository;
+    private final ReactionRepository reactionRepository;
+    private final CommentRepository commentRepository;
 
     /**
      * 회원 등록 완료 이벤트 처리
@@ -127,5 +133,46 @@ public class CollectionEventListener {
         collectionService.unlockCollection(event.memberId(), CollectionType.WOOD);
         log.info("회원 {}에게 나무곡괭이 뭉탱이 컬렉션이 해금되었습니다 (온보딩 완료 보상)",
                 event.memberId());
+    }
+
+    /**
+     * 감정표현 추가 이벤트 처리
+     * STICKER 컬렉션 해금 조건 체크 (첫 감정표현 사용)
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleReactionAdded(ReactionAddedEvent event) {
+        log.info("감정표현 추가 이벤트 수신 - reactionId: {}, memberId: {}", event.reactionId(), event.memberId());
+
+        // 첫 감정표현 사용 시 STICKER 컬렉션 해금
+        long reactionCount = reactionRepository.countByMemberId(event.memberId());
+        if (reactionCount == 1) {
+            collectionService.unlockCollection(event.memberId(), CollectionType.STICKER);
+        }
+    }
+
+    /**
+     * 댓글 작성 이벤트 처리
+     * GRADUATION(10개), KANE(100개) 컬렉션 해금 조건 체크
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleCommentCreated(CommentCreatedEvent event) {
+        log.info("댓글 작성 이벤트 수신 - commentId: {}, commenterId: {}", event.commentId(), event.commenterId());
+
+        // 댓글 작성 횟수 조회
+        long commentCount = commentRepository.countByMemberId(event.commenterId());
+
+        // GRADUATION 컬렉션 해금 (10개)
+        if (commentCount == 10) {
+            collectionService.unlockCollection(event.commenterId(), CollectionType.GRADUATION);
+            log.info("회원 {}의 댓글 10개 작성으로 GRADUATION 컬렉션이 해금되었습니다", event.commenterId());
+        }
+
+        // KANE 컬렉션 해금 (100개)
+        if (commentCount == 100) {
+            collectionService.unlockCollection(event.commenterId(), CollectionType.KANE);
+            log.info("회원 {}의 댓글 100개 작성으로 KANE 컬렉션이 해금되었습니다", event.commenterId());
+        }
     }
 }

--- a/src/main/java/econovation/moongtaengi/member/application/ExperienceEventListener.java
+++ b/src/main/java/econovation/moongtaengi/member/application/ExperienceEventListener.java
@@ -4,6 +4,7 @@ import econovation.moongtaengi.gamification.domain.QuestType;
 import econovation.moongtaengi.member.domain.event.LoginSuccessEvent;
 import econovation.moongtaengi.study.domain.comment.CommentCreatedEvent;
 import econovation.moongtaengi.study.domain.event.StudyCreatedEvent;
+import econovation.moongtaengi.study.domain.reaction.ReactionAddedEvent;
 import econovation.moongtaengi.study.domain.submission.SubmissionCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,5 +46,12 @@ public class ExperienceEventListener {
     public void handleCommentCreated(CommentCreatedEvent event) {
         log.info("CommentCreatedEvent 수신 - commentId: {}, commenterId: {}", event.commentId(), event.commenterId());
         experienceService.completeQuest(event.commenterId(), QuestType.COMMENT);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleReactionAdded(ReactionAddedEvent event) {
+        log.info("ReactionAddedEvent 수신 - reactionId: {}, memberId: {}", event.reactionId(), event.memberId());
+        experienceService.completeQuest(event.memberId(), QuestType.REACTION);
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/application/reaction/ToggleReactionService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/reaction/ToggleReactionService.java
@@ -2,11 +2,13 @@ package econovation.moongtaengi.study.application.reaction;
 
 import econovation.moongtaengi.study.domain.reaction.EmojiType;
 import econovation.moongtaengi.study.domain.reaction.Reaction;
+import econovation.moongtaengi.study.domain.reaction.ReactionAddedEvent;
 import econovation.moongtaengi.study.domain.reaction.ReactionMemberValidator;
 import econovation.moongtaengi.study.domain.reaction.ReactionRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +19,7 @@ public class ToggleReactionService {
 
     private final ReactionRepository reactionRepository;
     private final ReactionMemberValidator reactionMemberValidator;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void toggleReaction(Long submissionId, Long memberId, EmojiType emojiType) {
@@ -33,6 +36,14 @@ public class ToggleReactionService {
         } else {
             Reaction newReaction = Reaction.create(submissionId, memberId, emojiType);
             reactionRepository.save(newReaction);
+
+            // 감정표현 추가 이벤트 발행
+            eventPublisher.publishEvent(new ReactionAddedEvent(
+                    newReaction.getId(),
+                    submissionId,
+                    memberId,
+                    emojiType
+            ));
 
             log.info("감정표현 추가 성공 - submissionId: {}, memberId: {}, type: {}",
                     submissionId, memberId, emojiType);

--- a/src/main/java/econovation/moongtaengi/study/domain/comment/CommentRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/comment/CommentRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+    long countByMemberId(Long memberId);
 }

--- a/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionAddedEvent.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionAddedEvent.java
@@ -1,0 +1,12 @@
+package econovation.moongtaengi.study.domain.reaction;
+
+/**
+ * 감정표현 추가 이벤트
+ */
+public record ReactionAddedEvent(
+        Long reactionId,
+        Long submissionId,
+        Long memberId,
+        EmojiType emojiType
+) {
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/reaction/ReactionRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ReactionRepository extends JpaRepository<Reaction, Long> {
 
     Optional<Reaction> findBySubmissionIdAndMemberIdAndEmojiType(Long submissionId, Long memberId, EmojiType emojiType);
+
+    long countByMemberId(Long memberId);
 }

--- a/src/test/java/econovation/moongtaengi/study/application/ToggleReactionServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/ToggleReactionServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 public class ToggleReactionServiceTest {
@@ -34,6 +35,9 @@ public class ToggleReactionServiceTest {
 
     @Captor
     private ArgumentCaptor<Reaction> reactionCaptor;
+
+    @Mock
+    ApplicationEventPublisher applicationEventPublisher;
 
     @Test
     @DisplayName("기존에 감정표현이 없으면 권한 검사 후 저장한다.")


### PR DESCRIPTION
### 📌 PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈

### 🧑‍💻 구현한 내용
- 감정 표현시 일일 퀘스트 달성을 통한 경험치 발급 구현
- 감정 표현시 STICKER 뭉탱이 발급 구현
- 댓글 갯수 10개, 100개 달성 시 GRAUDATION, KANE 뭉탱이 발급 구현
- 감정 표현과 댓글 갯수를 세기 위한 countByMemberId를 reactionRepository와 commentRepository에 구현함

### 🧪 테스트 결과

### 👿 트러블 슈팅

### 💬 코멘트



