### PR TITLE
feat: 과제 설명 수정 API 구현 및 DTO 명칭 통일

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/api/AssignmentController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/AssignmentController.java
@@ -2,12 +2,15 @@ package econovation.moongtaengi.study.api;
 
 import econovation.moongtaengi.global.annotation.LoginMemberId;
 import econovation.moongtaengi.study.api.dto.AssignmentCreateRequest;
+import econovation.moongtaengi.study.api.dto.AssignmentUpdateRequest;
 import econovation.moongtaengi.study.application.assignment.ApproveAssignmentService;
 import econovation.moongtaengi.study.application.assignment.AssignmentDetail;
 import econovation.moongtaengi.study.application.assignment.AssignmentQueryService;
 import econovation.moongtaengi.study.application.assignment.AssignmentSummary;
 import econovation.moongtaengi.study.application.assignment.CreateAssignmentCommand;
 import econovation.moongtaengi.study.application.assignment.CreateAssignmentService;
+import econovation.moongtaengi.study.application.assignment.UpdateAssignmentService;
+import econovation.moongtaengi.study.application.assignment.UpdateDescriptionCommand;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
@@ -15,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,6 +35,7 @@ public class AssignmentController {
     private final CreateAssignmentService createAssignmentService;
     private final AssignmentQueryService assignmentQueryService;
     private final ApproveAssignmentService approveAssignmentService;
+    private final UpdateAssignmentService updateAssignmentService;
 
     @PostMapping
     public ResponseEntity<Void> createAssignment(
@@ -83,6 +88,20 @@ public class AssignmentController {
         log.info("과제 승인 API 호출 - requesterId: {}, assignmentId: {}", memberId, assignmentId);
 
         approveAssignmentService.approveAssignment(assignmentId, memberId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{assignmentId}")
+    public ResponseEntity<Void> updateAssignmentDescription(
+            @LoginMemberId Long requesterId,
+            @PathVariable Long assignmentId,
+            @RequestBody @Valid AssignmentUpdateRequest request
+    ) {
+        log.info("과제 설명 수정 API 호출 - requesterId: {}, assignmentId: {}", requesterId, assignmentId);
+
+        UpdateDescriptionCommand command = request.toCommand(assignmentId, requesterId);
+        updateAssignmentService.updateDescription(command);
+
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/api/dto/AssignmentCreateRequest.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/AssignmentCreateRequest.java
@@ -13,7 +13,7 @@ public record AssignmentCreateRequest(
         Long assigneeId,
 
         @NotBlank(message = "과제 내용은 필수입니다.")
-        String content,
+        String description,
 
         LocalDateTime deadLine
 ) {
@@ -22,7 +22,7 @@ public record AssignmentCreateRequest(
                         .processId(this.processId)
                         .requesterId(requesterId)
                         .assigneeId(this.assigneeId)
-                        .description(this.content)
+                        .description(this.description)
                         .deadline(this.deadLine)
                         .build();
         }

--- a/src/main/java/econovation/moongtaengi/study/api/dto/AssignmentCreateRequest.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/AssignmentCreateRequest.java
@@ -22,7 +22,7 @@ public record AssignmentCreateRequest(
                         .processId(this.processId)
                         .requesterId(requesterId)
                         .assigneeId(this.assigneeId)
-                        .content(this.content)
+                        .description(this.content)
                         .deadline(this.deadLine)
                         .build();
         }

--- a/src/main/java/econovation/moongtaengi/study/api/dto/AssignmentUpdateRequest.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/AssignmentUpdateRequest.java
@@ -1,0 +1,13 @@
+package econovation.moongtaengi.study.api.dto;
+
+import econovation.moongtaengi.study.application.assignment.UpdateDescriptionCommand;
+import jakarta.validation.constraints.NotBlank;
+
+public record AssignmentUpdateRequest(
+        @NotBlank(message = "수정할 과제 내용은 필수입니다.")
+        String description
+) {
+    public UpdateDescriptionCommand toCommand(Long assignmentId, Long requesterId) {
+        return UpdateDescriptionCommand.of(assignmentId, requesterId, description);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentDetail.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentDetail.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 public record AssignmentDetail(
         Long studyId,
         String studyName,
-        String assignmentContent,
+        String assignmentDescription,
         String nickname,
         String memberTitle,
         Long submissionId,
@@ -18,7 +18,7 @@ public record AssignmentDetail(
         return new AssignmentDetail(
                 raw.studyId(),
                 raw.studyName(),
-                raw.assignmentContent(),
+                raw.assignmentDescription(),
                 raw.nickname(),
                 Title.fromExperience(raw.totalExperience()).getDisplayName(),
                 raw.submissionId(),

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentSummary.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentSummary.java
@@ -6,7 +6,7 @@ public record AssignmentSummary(
         Long assignmentId,
         Long submissionId,
         Long memberId,
-        String assignmentContent,
+        String assignmentDescription,
         String nickname,
         AssignmentStatus status,
         Boolean isLate,

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentSummary.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/AssignmentSummary.java
@@ -14,7 +14,7 @@ public record AssignmentSummary(
         String fileUrl
 ) {
     public AssignmentSummary {
-        assignmentContent = (assignmentContent == null) ? "" : assignmentContent;
+        assignmentDescription = (assignmentDescription == null) ? "" : assignmentDescription;
         nickname = (nickname == null) ? "" : nickname;
         isLate = (isLate != null) && isLate;
         fileName = (fileName == null) ? "" : fileName;

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/CreateAssignmentCommand.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/CreateAssignmentCommand.java
@@ -8,7 +8,7 @@ public record CreateAssignmentCommand(
         Long processId,
         Long requesterId,
         Long assigneeId,
-        String content,
+        String description,
         LocalDateTime deadline
 ) {
 }

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/CreateAssignmentService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/CreateAssignmentService.java
@@ -1,7 +1,7 @@
 package econovation.moongtaengi.study.application.assignment;
 
 import econovation.moongtaengi.study.domain.assignment.Assignment;
-import econovation.moongtaengi.study.domain.assignment.AssignmentContent;
+import econovation.moongtaengi.study.domain.assignment.AssignmentDescription;
 import econovation.moongtaengi.study.domain.assignment.AssignmentDeadline;
 import econovation.moongtaengi.study.domain.assignment.AssignmentManagementPolicy;
 import econovation.moongtaengi.study.domain.assignment.AssignmentRepository;
@@ -39,12 +39,12 @@ public class CreateAssignmentService {
                 processInfo.endDate()
         );
 
-        AssignmentContent content = new AssignmentContent(command.content());
+        AssignmentDescription description = new AssignmentDescription(command.description());
 
         Assignment assignment = Assignment.builder()
                 .processId(command.processId())
                 .assigneeId(command.assigneeId())
-                .content(content)
+                .description(description)
                 .deadline(deadline)
                 .build();
 

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/UpdateAssignmentService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/UpdateAssignmentService.java
@@ -1,0 +1,39 @@
+package econovation.moongtaengi.study.application.assignment;
+
+import econovation.moongtaengi.study.domain.assignment.Assignment;
+import econovation.moongtaengi.study.domain.assignment.AssignmentDescription;
+import econovation.moongtaengi.study.domain.assignment.AssignmentErrorCode;
+import econovation.moongtaengi.study.domain.assignment.AssignmentException;
+import econovation.moongtaengi.study.domain.assignment.AssignmentManagementPolicy;
+import econovation.moongtaengi.study.domain.assignment.AssignmentRepository;
+import econovation.moongtaengi.study.domain.assignment.ProcessInfoProvider;
+import econovation.moongtaengi.study.domain.assignment.ProcessInfoProvider.ProcessInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UpdateAssignmentService {
+
+    private final AssignmentRepository repository;
+    private final AssignmentManagementPolicy policy;
+    private final ProcessInfoProvider infoProvider;
+
+    @Transactional
+    public void updateDescription(UpdateDescriptionCommand command) {
+        Assignment assignment = repository.findById(command.assignmentId())
+                .orElseThrow(() -> new AssignmentException(AssignmentErrorCode.ASSIGNMENT_NOT_FOUND));
+
+        ProcessInfo processInfo = infoProvider.getProcessInfo(assignment.getProcessId());
+
+        policy.validate(processInfo.studyId(), command.requesterId());
+
+        assignment.updateDescription(new AssignmentDescription(command.description()));
+
+        log.info("과제 설명 수정 완료 - assignmentId: {}, requesterId: {}",
+                assignment.getId(), command.requesterId());
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/UpdateDescriptionCommand.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/UpdateDescriptionCommand.java
@@ -1,0 +1,11 @@
+package econovation.moongtaengi.study.application.assignment;
+
+public record UpdateDescriptionCommand(
+        Long assignmentId,
+        Long requesterId,
+        String description
+) {
+    public static UpdateDescriptionCommand of(Long assignmentId, Long requesterId, String description) {
+        return new UpdateDescriptionCommand(assignmentId, requesterId, description);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/Assignment.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/Assignment.java
@@ -65,9 +65,28 @@ public class Assignment extends BaseEntity {
         registerEvent(new AssignmentApprovedEvent(this.getId(), this.assigneeId));
     }
 
+    public void updateDescription(AssignmentDescription newDescription) {
+        validateDescription(newDescription);
+        validateUpdatable();
+
+        this.description = newDescription;
+    }
+
     private static void validate(Long processId, Long assigneeId, AssignmentDescription description, AssignmentDeadline deadline) {
         if (processId == null || assigneeId == null || description == null || deadline == null) {
             throw new AssignmentException(AssignmentErrorCode.INVALID_ASSIGNMENT_INFO);
+        }
+    }
+
+    private void validateDescription(AssignmentDescription newDescription) {
+        if (newDescription == null) {
+            throw new AssignmentException(AssignmentErrorCode.INVALID_ASSIGNMENT_INFO);
+        }
+    }
+
+    private void validateUpdatable() {
+        if (this.status != AssignmentStatus.WAITING) {
+            throw new AssignmentException(AssignmentErrorCode.UPDATE_ALLOWED_ONLY_IN_WAITING);
         }
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/Assignment.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/Assignment.java
@@ -24,7 +24,7 @@ public class Assignment extends BaseEntity {
     private Long assigneeId;
 
     @Embedded
-    private AssignmentContent content;
+    private AssignmentDescription description;
 
     @Embedded
     private AssignmentDeadline deadline;
@@ -36,20 +36,20 @@ public class Assignment extends BaseEntity {
     @Column(name = "is_late", nullable = false)
     private boolean isLate;
 
-    private Assignment(Long processId, Long assigneeId, AssignmentContent content, AssignmentDeadline deadline) {
+    private Assignment(Long processId, Long assigneeId, AssignmentDescription description, AssignmentDeadline deadline) {
         this.processId = processId;
         this.assigneeId = assigneeId;
-        this.content = content;
+        this.description = description;
         this.deadline = deadline;
         this.status = AssignmentStatus.WAITING;
         this.isLate = false;
     }
 
     @Builder
-    public static Assignment create(Long processId, Long assigneeId, AssignmentContent content, AssignmentDeadline deadline) {
-        validate(processId, assigneeId, content, deadline);
+    public static Assignment create(Long processId, Long assigneeId, AssignmentDescription description, AssignmentDeadline deadline) {
+        validate(processId, assigneeId, description, deadline);
 
-        return new Assignment(processId, assigneeId, content, deadline);
+        return new Assignment(processId, assigneeId, description, deadline);
     }
 
     public void markAsSubmitted(boolean isLate) {
@@ -65,8 +65,8 @@ public class Assignment extends BaseEntity {
         registerEvent(new AssignmentApprovedEvent(this.getId(), this.assigneeId));
     }
 
-    private static void validate(Long processId, Long assigneeId, AssignmentContent content, AssignmentDeadline deadline) {
-        if (processId == null || assigneeId == null || content == null || deadline == null) {
+    private static void validate(Long processId, Long assigneeId, AssignmentDescription description, AssignmentDeadline deadline) {
+        if (processId == null || assigneeId == null || description == null || deadline == null) {
             throw new AssignmentException(AssignmentErrorCode.INVALID_ASSIGNMENT_INFO);
         }
     }

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentDescription.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentDescription.java
@@ -11,13 +11,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode
-public class AssignmentContent {
+public class AssignmentDescription {
     private static final int MAX_LENGTH = 300;
 
-    @Column(name = "content", nullable = false, length = MAX_LENGTH)
+    @Column(name = "description", nullable = false, length = MAX_LENGTH)
     private String value;
 
-    public AssignmentContent(String value) {
+    public AssignmentDescription(String value) {
         validate(value);
         this.value = value.trim();
     }

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentDetailRaw.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentDetailRaw.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 public record AssignmentDetailRaw(
         Long studyId,
         String studyName,
-        String assignmentContent,
+        String assignmentDescription,
         String nickname,
         Long assigneeId,
         int totalExperience,

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentErrorCode.java
@@ -18,7 +18,9 @@ public enum AssignmentErrorCode implements ErrorCode {
 
     ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "AS_005", "존재하지 않는 과제입니다."),
 
-    CANNOT_APPROVE_NOT_SUBMITTED(HttpStatus.BAD_REQUEST, "AS_006", "제출되지 않은 과제는 승인할 수 없습니다.");
+    CANNOT_APPROVE_NOT_SUBMITTED(HttpStatus.BAD_REQUEST, "AS_006", "제출되지 않은 과제는 승인할 수 없습니다."),
+
+    UPDATE_ALLOWED_ONLY_IN_WAITING(HttpStatus.BAD_REQUEST, "AS_007","과제 내용은 WAITING 상태에서만 수정 가능합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepository.java
@@ -17,7 +17,7 @@ public interface AssignmentRepository extends JpaRepository<Assignment, Long> {
             a.id,
             s.id,
             m.id,
-            a.content.value,
+            a.description.value,
             m.nickname.value,
             a.status,
             a.isLate,
@@ -51,7 +51,7 @@ public interface AssignmentRepository extends JpaRepository<Assignment, Long> {
         SELECT new econovation.moongtaengi.study.domain.assignment.AssignmentDetailRaw(
             s.id,
             s.name.value,
-            a.content.value,
+            a.description.value,
             m.nickname.value,
             a.assigneeId,
             m.totalExperience,

--- a/src/test/java/econovation/moongtaengi/study/api/AssignmentControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/AssignmentControllerTest.java
@@ -109,7 +109,7 @@ public class AssignmentControllerTest {
 
         assertThat(command.processId()).isEqualTo(request.processId());
         assertThat(command.requesterId()).isEqualTo(1L);
-        assertThat(command.content()).isEqualTo(request.content());
+        assertThat(command.description()).isEqualTo(request.content());
         assertThat(command.deadline()).isEqualTo(deadline);
     }
 
@@ -249,7 +249,7 @@ public class AssignmentControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.studyId").value(100L))
                 .andExpect(jsonPath("$.studyName").value("테스트 스터디"))
-                .andExpect(jsonPath("$.assignmentContent").value("테스트 과제"))
+                .andExpect(jsonPath("$.assignmentDescription").value("테스트 과제"))
                 .andExpect(jsonPath("$.nickname").value("지환"))
                 .andExpect(jsonPath("$.memberTitle").value("비기너"))
                 .andExpect(jsonPath("$.isOwner").value(true))

--- a/src/test/java/econovation/moongtaengi/study/api/AssignmentControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/AssignmentControllerTest.java
@@ -11,6 +11,7 @@ import econovation.moongtaengi.global.config.WebConfig;
 import econovation.moongtaengi.global.security.CustomAuthentication;
 import econovation.moongtaengi.global.security.LoginMemberIdArgumentResolver;
 import econovation.moongtaengi.study.api.dto.AssignmentCreateRequest;
+import econovation.moongtaengi.study.api.dto.AssignmentUpdateRequest;
 import econovation.moongtaengi.study.application.assignment.ApproveAssignmentService;
 import econovation.moongtaengi.study.application.assignment.AssignmentDetail;
 import econovation.moongtaengi.study.application.assignment.AssignmentQueryService;
@@ -20,12 +21,15 @@ import econovation.moongtaengi.study.application.assignment.CreateAssignmentServ
 
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import econovation.moongtaengi.study.application.assignment.UpdateAssignmentService;
+import econovation.moongtaengi.study.application.assignment.UpdateDescriptionCommand;
 import econovation.moongtaengi.study.domain.StudyErrorCode;
 import econovation.moongtaengi.study.domain.StudyException;
 import econovation.moongtaengi.study.domain.assignment.AssignmentErrorCode;
@@ -71,6 +75,9 @@ public class AssignmentControllerTest {
     @MockitoBean
     private ApproveAssignmentService approveAssignmentService;
 
+    @MockitoBean
+    private UpdateAssignmentService updateAssignmentService;
+
     @BeforeEach
     void setUp() {
         SecurityContextHolder.getContext().setAuthentication(new CustomAuthentication(1L));
@@ -109,7 +116,7 @@ public class AssignmentControllerTest {
 
         assertThat(command.processId()).isEqualTo(request.processId());
         assertThat(command.requesterId()).isEqualTo(1L);
-        assertThat(command.description()).isEqualTo(request.content());
+        assertThat(command.description()).isEqualTo(request.description());
         assertThat(command.deadline()).isEqualTo(deadline);
     }
 
@@ -302,5 +309,47 @@ public class AssignmentControllerTest {
                 .andExpect(status().isOk());
 
         verify(approveAssignmentService).approveAssignment(assignmentId, requesterId);
+    }
+
+    @Test
+    @DisplayName("과제 설명 수정 요청 시 서비스를 호출하고 200 OK를 반환한다")
+    void 과제_설명_수정_성공() throws Exception {
+        //given
+        Long assignmentId = 1L;
+        Long requesterId = 1L;
+        String newDescription = "수정된 과제 내용";
+
+        AssignmentUpdateRequest request = new AssignmentUpdateRequest(newDescription);
+
+        //when&then
+        mvc.perform(patch("/api/assignments/{assignmentId}", assignmentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<UpdateDescriptionCommand> captor = ArgumentCaptor.forClass(
+                UpdateDescriptionCommand.class);
+        verify(updateAssignmentService).updateDescription(captor.capture());
+
+        UpdateDescriptionCommand capturedCommand = captor.getValue();
+        assertThat(capturedCommand.assignmentId()).isEqualTo(assignmentId);
+        assertThat(capturedCommand.requesterId()).isEqualTo(requesterId);
+        assertThat(capturedCommand.description()).isEqualTo(newDescription);
+    }
+
+    @Test
+    @DisplayName("수정할 내용이 비어있으면 400 Bad Request를 반환한다")
+    void 과제_설명_수정_실패_유효성검사() throws Exception {
+        //given
+        Long assignmentId = 1L;
+        AssignmentUpdateRequest badRequest = new AssignmentUpdateRequest("");
+
+        //when&then
+        mvc.perform(patch("/api/assignments/{assignmentId}", assignmentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(badRequest)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/application/AssignmentQueryServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/AssignmentQueryServiceTest.java
@@ -137,7 +137,7 @@ class AssignmentQueryServiceTest {
         assertThat(result.memberTitle()).isEqualTo(Title.fromExperience(experience).getDisplayName());
         assertThat(result.isOwner()).isTrue();
         assertThat(result.studyName()).isEqualTo("테스트 스터디");
-        assertThat(result.assignmentContent()).isEqualTo("테스트 과제");
+        assertThat(result.assignmentDescription()).isEqualTo("테스트 과제");
     }
 
     @Test

--- a/src/test/java/econovation/moongtaengi/study/application/CreateAssignmentServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/CreateAssignmentServiceTest.java
@@ -58,7 +58,7 @@ public class CreateAssignmentServiceTest {
                 .processId(DEFAULT_PROCESS_ID)
                 .requesterId(10L)
                 .assigneeId(DEFAULT_ASSIGNEE_ID)
-                .content(DEFAULT_CONTENT.getValue())
+                .description(DEFAULT_DESCRIPTION.getValue())
                 .deadline(requestDeadline)
                 .build();
 

--- a/src/test/java/econovation/moongtaengi/study/application/UpdateAssignmentServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/UpdateAssignmentServiceTest.java
@@ -1,0 +1,97 @@
+package econovation.moongtaengi.study.application;
+
+import static econovation.moongtaengi.study.domain.assignment.AssignmentFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import econovation.moongtaengi.study.application.assignment.UpdateAssignmentService;
+import econovation.moongtaengi.study.application.assignment.UpdateDescriptionCommand;
+import econovation.moongtaengi.study.domain.assignment.Assignment;
+import econovation.moongtaengi.study.domain.assignment.AssignmentErrorCode;
+import econovation.moongtaengi.study.domain.assignment.AssignmentException;
+import econovation.moongtaengi.study.domain.assignment.AssignmentManagementPolicy;
+import econovation.moongtaengi.study.domain.assignment.AssignmentRepository;
+import econovation.moongtaengi.study.domain.assignment.ProcessInfoProvider;
+import econovation.moongtaengi.study.domain.assignment.ProcessInfoProvider.ProcessInfo;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UpdateAssignmentServiceTest {
+
+        @Mock
+        private AssignmentRepository repository;
+        @Mock
+        private AssignmentManagementPolicy policy;
+        @Mock
+        private ProcessInfoProvider infoProvider;
+
+        @InjectMocks
+        private UpdateAssignmentService updateAssignmentService;
+
+        @Test
+        @DisplayName("방장은 과제 설명을 수정할 수 있다")
+        void 과제_설명_수정_성공() {
+            //given
+            Long assignmentId = 1L;
+            Long requesterId = 10L;
+            Long processId = 50L;
+            Long studyId = 99L;
+            String newDescriptionValue = "수정된 과제 내용";
+
+            UpdateDescriptionCommand command = UpdateDescriptionCommand.of(
+                    assignmentId, requesterId, newDescriptionValue
+            );
+
+            Assignment assignment = anAssignment()
+                    .processId(processId)
+                    .build();
+
+            ProcessInfo processInfo = new ProcessInfo(studyId,
+                    LocalDate.now(), LocalDate.now().plusDays(7));
+
+            given(repository.findById(assignmentId)).willReturn(Optional.of(assignment));
+            given(infoProvider.getProcessInfo(processId)).willReturn(processInfo);
+
+            //when
+            updateAssignmentService.updateDescription(command);
+
+            //then
+            verify(infoProvider).getProcessInfo(processId);
+            verify(policy).validate(studyId, requesterId);
+            assertThat(assignment.getDescription().getValue()).isEqualTo(newDescriptionValue);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 과제는 수정할 수 없다")
+        void 과제_설명_수정_실패_과제_미존재() {
+            //given
+            Long nonExistentId = 999L;
+            UpdateDescriptionCommand command = UpdateDescriptionCommand.of(
+                    nonExistentId,
+                    10L,
+                    "수정하려는 내용"
+            );
+
+            given(repository.findById(nonExistentId)).willReturn(Optional.empty());
+
+            //when&then
+            assertThatThrownBy(() -> updateAssignmentService.updateDescription(command))
+                    .isInstanceOf(AssignmentException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(AssignmentErrorCode.ASSIGNMENT_NOT_FOUND);
+
+            verify(infoProvider, never()).getProcessInfo(any());
+            verify(policy, never()).validate(any(), any());
+        }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentFixture.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentFixture.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 public class AssignmentFixture {
     public static final Long DEFAULT_PROCESS_ID = 1L;
     public static final Long DEFAULT_ASSIGNEE_ID = 1L;
-    public static final AssignmentContent DEFAULT_CONTENT = new AssignmentContent("테스트 과제");
+    public static final AssignmentDescription DEFAULT_DESCRIPTION = new AssignmentDescription("테스트 과제");
 
     public static final LocalDate BASE_DATE = StudyFixture.FIXED_DATE;
 
@@ -14,7 +14,7 @@ public class AssignmentFixture {
         return Assignment.builder()
                 .processId(DEFAULT_PROCESS_ID)
                 .assigneeId(DEFAULT_ASSIGNEE_ID)
-                .content(DEFAULT_CONTENT)
+                .description(DEFAULT_DESCRIPTION)
                 .deadline(AssignmentDeadline.create(
                         BASE_DATE.plusDays(7).atStartOfDay(),
                         BASE_DATE,

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepositoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentRepositoryTest.java
@@ -135,7 +135,7 @@ public class AssignmentRepositoryTest {
 
         //then
         assertThat(result.studyName()).isEqualTo(study.getName().getValue());
-        assertThat(result.assignmentContent()).isEqualTo("테스트 과제");
+        assertThat(result.assignmentDescription()).isEqualTo("테스트 과제");
         assertThat(result.nickname()).isEqualTo("지환");
         assertThat(result.totalExperience()).isEqualTo(500);
         assertThat(result.submissionId()).isEqualTo(submission.getId());
@@ -166,7 +166,7 @@ public class AssignmentRepositoryTest {
         //then
         assertThat(result.submissionId()).isNull();
         assertThat(result.submitTime()).isNull();
-        assertThat(result.assignmentContent()).isEqualTo("테스트 과제");
+        assertThat(result.assignmentDescription()).isEqualTo("테스트 과제");
     }
 
 

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentTest.java
@@ -78,4 +78,64 @@ public class AssignmentTest {
                 .extracting("errorCode")
                 .isEqualTo(AssignmentErrorCode.CANNOT_APPROVE_NOT_SUBMITTED);
     }
+
+    @Test
+    @DisplayName("과제 상태가 WAITING일 때, 과제 설명을 수정할 수 있다.")
+    void 과제_설명_수정_성공() {
+        //given
+        Assignment assignment = anAssignment().build();
+        AssignmentDescription newDescription = new AssignmentDescription("수정된 설명");
+
+        //when
+        assignment.updateDescription(newDescription);
+
+        //then
+        assertThat(assignment.getDescription()).isEqualTo(newDescription);
+    }
+
+    @Test
+    @DisplayName("이미 제출된 과제는 설명을 수정할 수 없다.")
+    void 과제_설명_수정_실패_이미_제출됨() {
+        //given
+        Assignment assignment = anAssignment().build();
+        assignment.markAsSubmitted(false);
+
+        AssignmentDescription newDescription = new AssignmentDescription("수정된 설명");
+
+        //when&then
+        assertThatThrownBy(() -> assignment.updateDescription(newDescription))
+                .isInstanceOf(AssignmentException.class)
+                .extracting("errorCode")
+                .isEqualTo(AssignmentErrorCode.UPDATE_ALLOWED_ONLY_IN_WAITING);
+    }
+
+    @Test
+    @DisplayName("이미 승인된 과제도 설명을 수정할 수 없다.")
+    void 과제_설명_수정_실패_이미_승인됨() {
+        // given
+        Assignment assignment = anAssignment().build();
+        assignment.markAsSubmitted(false);
+        assignment.approve();
+
+        AssignmentDescription newDescription = new AssignmentDescription("수정된 설명");
+
+        //when&then
+        assertThatThrownBy(() -> assignment.updateDescription(newDescription))
+                .isInstanceOf(AssignmentException.class)
+                .extracting("errorCode")
+                .isEqualTo(AssignmentErrorCode.UPDATE_ALLOWED_ONLY_IN_WAITING);
+    }
+
+    @Test
+    @DisplayName("수정할 설명이 null이면 예외가 발생한다.")
+    void 과제_설명_수정_실패_Null_입력() {
+        // given
+        Assignment assignment = anAssignment().build();
+
+        //when&then
+        assertThatThrownBy(() -> assignment.updateDescription(null))
+                .isInstanceOf(AssignmentException.class)
+                .extracting("errorCode")
+                .isEqualTo(AssignmentErrorCode.INVALID_ASSIGNMENT_INFO);
+    }
 }

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentTest.java
@@ -15,8 +15,8 @@ public class AssignmentTest {
         Assignment assignment = anAssignment().build();
 
         //then
-        assertThat(assignment.getContent())
-                .isEqualTo(AssignmentFixture.DEFAULT_CONTENT);
+        assertThat(assignment.getDescription())
+                .isEqualTo(AssignmentFixture.DEFAULT_DESCRIPTION);
     }
 
     @Test
@@ -32,8 +32,8 @@ public class AssignmentTest {
 
         //then
         assertThat(assignment.getAssigneeId()).isEqualTo(newAssigneeId);
-        assertThat(assignment.getContent())
-                .isEqualTo(AssignmentFixture.DEFAULT_CONTENT);
+        assertThat(assignment.getDescription())
+                .isEqualTo(AssignmentFixture.DEFAULT_DESCRIPTION);
     }
 
     @Test

--- a/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentVOTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/assignment/AssignmentVOTest.java
@@ -19,7 +19,7 @@ public class AssignmentVOTest {
         @DisplayName("과제 내용을 성공적으로 생성한다.")
         void 과제_내용_성공() {
             String value = "테스트 내용";
-            AssignmentContent description = new AssignmentContent(value);
+            AssignmentDescription description = new AssignmentDescription(value);
 
             assertThat(description.getValue()).isEqualTo(value);
         }
@@ -28,16 +28,16 @@ public class AssignmentVOTest {
         @DisplayName("앞뒤 공백은 자동으로 제거된다.")
         void 과제_내용_공백_제거() {
             String value = "  공백이 많은 내용  ";
-            AssignmentContent title = new AssignmentContent(value);
+            AssignmentDescription description = new AssignmentDescription(value);
 
-            assertThat(title.getValue()).isEqualTo("공백이 많은 내용");
+            assertThat(description.getValue()).isEqualTo("공백이 많은 내용");
         }
 
         @ParameterizedTest
         @NullAndEmptySource
         @DisplayName("과제 내용은 null이거나 비어있을 수 없다")
         void 과제_내용_비었음_실패(String invalidInput) {
-            assertThatThrownBy(() -> new AssignmentContent(invalidInput))
+            assertThatThrownBy(() -> new AssignmentDescription(invalidInput))
                     .isInstanceOf(AssignmentException.class)
                     .extracting("errorCode")
                     .isEqualTo(AssignmentErrorCode.INVALID_ASSIGNMENT_INFO);
@@ -48,7 +48,7 @@ public class AssignmentVOTest {
         void 과제_내용_초과_실패() {
             String longContent = "뭉".repeat(400);
 
-            assertThatThrownBy(() -> new AssignmentContent(longContent))
+            assertThatThrownBy(() -> new AssignmentDescription(longContent))
                     .isInstanceOf(AssignmentException.class)
                     .extracting("errorCode")
                     .isEqualTo(AssignmentErrorCode.INVALID_ASSIGNMENT_INFO);


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
1. 리팩토링
- 도메인 용어 명확화: `AssignmentContent`를 `AssignmentDescription`으로 변경
- DTO 필드명 통일:API의 일관성을 위해 `AssignmentCreateRequest`, `AssignmentSummary` 등 DTO의 필드명을 `content`에서 `description`으로 변경

2. 도메인
- 비즈니스 로직 구현: `Assignment` 엔티티에 `updateDescription` 메서드를 구현.
- 수정 정책 적용: 이미 제출된 과제의 무결성을 지키기 위해, 과제 상태가 WAITING(미제출)일 때만 수정 가능하도록 `validateUpdatable` 검증 로직을 추가.
- 에러 코드 정의: 상태 위반 시 발생할 에러 코드 `UPDATE_ALLOWED_ONLY_IN_WAITING(AS_007)`을 추가.

3. 애플리케이션
- UpdateAssignmentService: JPA Dirty Checking을 활용하여 별도의 `save` 호출 없이 트랜잭션 내에서 수정 사항이 반영되도록 구현
- 권한 검증 흐름: `Assignment`는 `ProcessId`만 보유하고 있으므로, `ProcessInfoProvider`를 통해 상위 개념인 `StudyId`를 조회하고, 이를 기반으로 `AssignmentManagementPolicy`를 호출하여 요청자의 권한을 검증하도록 설계.
- Command 객체: `UpdateDescriptionCommand`에 정적 팩토리 메서드(`of`)를 도입.

4. Presentation
- API 구현: `PATCH /api/assignments/{assignmentId}` 엔드포인트를 구현.

5. 테스트
- Entity Test: 성공 케이스 및 상태 위반(`SUBMITTED`, `APPROVED`), Null 입력에 대한 단위 테스트를 작성.
- Service Test: `Provider` → `Policy` → `Entity`로 이어지는 호출 흐름과 예외(`ASSIGNMENT_NOT_FOUND`) 처리를 검증.
- Controller Test (WebMvcTest): 정상 요청 처리(200 OK) 및 Validation 실패(Description 누락) 시 400 Bad Request 반환을 검증
### 🧪 테스트 결과
- [x] 테스트 코드 모두 통과했습니다!
- [x] 포스트맨, h2-console 테스트
<img width="671" height="435" alt="image" src="https://github.com/user-attachments/assets/2de04559-139b-4496-a231-ebe455d5824a" />
<img width="656" height="362" alt="image" src="https://github.com/user-attachments/assets/19133c2e-4609-4a6f-84c4-65ce3f91cc2f" />
 
### 👿 트러블 슈팅

### 💬 코멘트



