### PR TITLE
feat: 탑러너 관련 로직 및 메인페이지 조회 API 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/collection/application/CollectionEventListener.java
+++ b/src/main/java/econovation/moongtaengi/collection/application/CollectionEventListener.java
@@ -2,6 +2,7 @@ package econovation.moongtaengi.collection.application;
 
 import econovation.moongtaengi.collection.domain.CollectionType;
 import econovation.moongtaengi.collection.domain.event.CollectionUnlockedEvent;
+import econovation.moongtaengi.member.domain.event.TopRunnerSelectedEvent;
 import econovation.moongtaengi.member.domain.event.ExperienceAddedEvent;
 import econovation.moongtaengi.member.domain.event.MemberRegisteredEvent;
 import econovation.moongtaengi.onboarding.domain.event.OnboardingMissionCompletedEvent;
@@ -14,6 +15,7 @@ import econovation.moongtaengi.study.domain.reaction.ReactionAddedEvent;
 import econovation.moongtaengi.study.domain.reaction.ReactionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -174,5 +176,23 @@ public class CollectionEventListener {
             collectionService.unlockCollection(event.commenterId(), CollectionType.KANE);
             log.info("회원 {}의 댓글 100개 작성으로 KANE 컬렉션이 해금되었습니다", event.commenterId());
         }
+    }
+
+    /**
+     * 탑러너 선정 이벤트 처리
+     * TOP_RUNNER 컬렉션 해금
+     * 스케줄러로부터 발행된 이벤트 (트랜잭션 없음)
+     */
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleTopRunnerSelected(TopRunnerSelectedEvent event) {
+        log.info("탑러너 선정 이벤트 수신 - 선정된 회원 수: {}", event.memberIds().size());
+
+        // 각 탑러너에게 TOP_RUNNER 컬렉션 해금
+        for (Long memberId : event.memberIds()) {
+            collectionService.unlockCollection(memberId, CollectionType.TOP_RUNNER);
+        }
+
+        log.info("탑러너 컬렉션 해금 완료 - 처리된 회원 수: {}", event.memberIds().size());
     }
 }

--- a/src/main/java/econovation/moongtaengi/collection/domain/CollectionType.java
+++ b/src/main/java/econovation/moongtaengi/collection/domain/CollectionType.java
@@ -92,18 +92,18 @@ public enum CollectionType {
             "학사모 뭉탱이",
             CollectionRarity.EPIC,
             "댓글 10개 작성하기",
-                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood1.png",
-                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood2.png",
-                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood_bg.png"
+                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/graduation/graduation1.png",
+                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/graduation/graduation2.png",
+                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/graduation/graduation_bg.png"
     ),
 
     KANE(
             "케인 뭉탱이",
             CollectionRarity.UNIQUE,
             "댓글 100개 작성하기",
-                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood1.png",
-                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood2.png",
-                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood_bg.png"
+                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/kane/kane1.png",
+                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/kane/kane2.png",
+                    "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/kane/kane_bg.png"
     ),
 
     // 감정표현
@@ -111,9 +111,9 @@ public enum CollectionType {
             "스티커 뭉탱이",
             CollectionRarity.RARE,
             "감정 표현 사용하기",
-            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood1.png",
-            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood2.png",
-            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood_bg.png"
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/sticker/sticker1.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/sticker/sticker2.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/sticker/sticker_bg.png"
     ),
 
     // 탑러너
@@ -121,9 +121,9 @@ public enum CollectionType {
             "탑러너 뭉탱이",
             CollectionRarity.UNIQUE,
             "탑러너에 입성하기",
-            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood1.png",
-            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood2.png",
-            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/wood/wood_bg.png"
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/topRunner/topRunner1.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/topRunner/topRunner2.png",
+            "https://moongtaengi-dev.s3.ap-northeast-2.amazonaws.com/collection/topRunner/topRunner_bg.png"
     );
 
     private final String displayName;

--- a/src/main/java/econovation/moongtaengi/global/security/config/SecurityConfig.java
+++ b/src/main/java/econovation/moongtaengi/global/security/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
 
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/favicon.ico", "/error", "/css/**", "/js/**", "/images/**").permitAll()
                         // 인증 불필요 (public)
                         .requestMatchers(
                                 "/api/auth/kakao/callback",

--- a/src/main/java/econovation/moongtaengi/home/api/HomeController.java
+++ b/src/main/java/econovation/moongtaengi/home/api/HomeController.java
@@ -1,0 +1,37 @@
+package econovation.moongtaengi.home.api;
+
+import econovation.moongtaengi.global.annotation.LoginMemberId;
+import econovation.moongtaengi.home.api.dto.HomeResponse;
+import econovation.moongtaengi.home.application.HomeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 메인 페이지 API 컨트롤러
+ * 사용자 대시보드 정보 제공
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/home")
+public class HomeController {
+
+    private final HomeService homeService;
+
+    /**
+     * 메인 페이지 정보 조회
+     * @param memberId 로그인한 회원 ID
+     * @return 메인 페이지 응답
+     */
+    @GetMapping
+    public ResponseEntity<HomeResponse> getHomeInfo(@LoginMemberId Long memberId) {
+        log.info("메인 페이지 조회 API 호출 - memberId: {}", memberId);
+
+        HomeResponse response = homeService.getHomeInfo(memberId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/home/api/dto/HomeResponse.java
+++ b/src/main/java/econovation/moongtaengi/home/api/dto/HomeResponse.java
@@ -1,0 +1,32 @@
+package econovation.moongtaengi.home.api.dto;
+
+import java.util.List;
+
+/**
+ * 메인 페이지 응답
+ * @param nickname 사용자 닉네임
+ * @param equippedCollectionName 장착한 컬렉션 이름
+ * @param equippedCollectionIconUrl 장착한 컬렉션 아이콘 URL
+ * @param equippedCollectionBackgroundUrl 장착한 컬렉션 배경 URL
+ * @param cheeringMessage 응원 메시지
+ * @param commentCount 댓글 수
+ * @param activityTitle 활동 칭호
+ * @param collectionCount 보유 컬렉션 수
+ * @param totalExperience 총 경험치
+ * @param shortcutStudyId 바로가기 스터디 ID (없으면 null)
+ * @param topRunners 탑러너 목록 (최대 5명)
+ */
+public record HomeResponse(
+        String nickname,
+        String equippedCollectionName,
+        String equippedCollectionIconUrl,
+        String equippedCollectionBackgroundUrl,
+        String cheeringMessage,
+        Long commentCount,
+        String activityTitle,
+        Long collectionCount,
+        int totalExperience,
+        Long shortcutStudyId,
+        List<TopRunnerInfo> topRunners
+) {
+}

--- a/src/main/java/econovation/moongtaengi/home/api/dto/TopRunnerInfo.java
+++ b/src/main/java/econovation/moongtaengi/home/api/dto/TopRunnerInfo.java
@@ -1,0 +1,12 @@
+package econovation.moongtaengi.home.api.dto;
+
+/**
+ * 탑러너 정보
+ * @param nickname 닉네임
+ * @param profileIconUrl 프로필 아이콘 URL
+ */
+public record TopRunnerInfo(
+        String nickname,
+        String profileIconUrl
+) {
+}

--- a/src/main/java/econovation/moongtaengi/home/application/HomeService.java
+++ b/src/main/java/econovation/moongtaengi/home/application/HomeService.java
@@ -1,0 +1,104 @@
+package econovation.moongtaengi.home.application;
+
+import econovation.moongtaengi.collection.application.CollectionService;
+import econovation.moongtaengi.home.api.dto.HomeResponse;
+import econovation.moongtaengi.home.api.dto.TopRunnerInfo;
+import econovation.moongtaengi.member.application.MemberNotFoundException;
+import econovation.moongtaengi.member.domain.Member;
+import econovation.moongtaengi.member.domain.MemberRepository;
+import econovation.moongtaengi.study.domain.StudyMember;
+import econovation.moongtaengi.study.domain.StudyMemberRepository;
+import econovation.moongtaengi.study.domain.comment.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Random;
+
+/**
+ * 메인 페이지 서비스
+ * 사용자 정보 및 탑러너 정보 제공
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HomeService {
+
+    private final MemberRepository memberRepository;
+    private final CollectionService collectionService;
+    private final CommentRepository commentRepository;
+    private final StudyMemberRepository studyMemberRepository;
+    private final Random random = new Random();
+
+    private static final List<String> CHEERING_MESSAGES = List.of(
+            "오늘도 화이팅!",
+            "뭉탱이와 함께 달려요!",
+            "꾸준함이 답이다!",
+            "당신은 할 수 있어요!",
+            "조금씩 성장하고 있어요!",
+            "멋진 하루 되세요!",
+            "함께 공부해요!",
+            "오늘도 좋은 하루!",
+            "열심히 하는 당신, 멋져요!",
+            "작은 노력이 모여 큰 결과를 만들어요!"
+    );
+
+    /**
+     * 메인 페이지 정보 조회
+     * @param memberId 회원 ID
+     * @return 메인 페이지 응답
+     */
+    public HomeResponse getHomeInfo(Long memberId) {
+        // 회원 정보 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        // 랜덤 응원 메시지 선택
+        String cheeringMessage = CHEERING_MESSAGES.get(random.nextInt(CHEERING_MESSAGES.size()));
+
+        // 댓글 수 조회
+        long commentCount = commentRepository.countByMemberId(memberId);
+
+        // 컬렉션 수 조회
+        long collectionCount = collectionService.getCollectionCount(memberId);
+
+        // 바로가기 스터디 ID 조회 (가장 최근 업데이트된 스터디)
+        Long shortcutStudyId = studyMemberRepository
+                .findMostRecentStudyByMemberId(memberId, PageRequest.of(0, 1))
+                .stream()
+                .findFirst()
+                .map(StudyMember::getStudy)
+                .map(study -> study.getId())
+                .orElse(null);
+
+        // 탑러너 목록 조회
+        List<TopRunnerInfo> topRunners = memberRepository
+                .findTopMembersByExperience(PageRequest.of(0, 5))
+                .stream()
+                .map(topMember -> new TopRunnerInfo(
+                        topMember.getNickname().getValue(),
+                        topMember.getProfileIcon().getUnlockedImageUrl()
+                ))
+                .toList();
+
+        log.info("회원 {}의 메인 페이지 정보를 조회했습니다", memberId);
+
+        return new HomeResponse(
+                member.getNickname().getValue(),
+                member.getProfileIcon().getDisplayName(),
+                member.getProfileIcon().getUnlockedImageUrl(),
+                member.getProfileIcon().getBackgroundImageUrl(),
+                cheeringMessage,
+                commentCount,
+                member.getTitle().getDisplayName(),
+                collectionCount,
+                member.getTotalExperience(),
+                shortcutStudyId,
+                topRunners
+        );
+    }
+}

--- a/src/main/java/econovation/moongtaengi/member/application/TopRunnerScheduler.java
+++ b/src/main/java/econovation/moongtaengi/member/application/TopRunnerScheduler.java
@@ -1,0 +1,60 @@
+package econovation.moongtaengi.member.application;
+
+import econovation.moongtaengi.member.domain.event.TopRunnerSelectedEvent;
+import econovation.moongtaengi.member.domain.Member;
+import econovation.moongtaengi.member.domain.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 탑러너 스케줄러
+ * - 10분마다 경험치 상위 5명 선정
+ * - TopRunnerSelectedEvent 발행 (컬렉션 해금은 CollectionEventListener가 처리)
+ * - 한번 해금되면 순위에서 밀려나도 회수하지 않음
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TopRunnerScheduler {
+
+    private final MemberRepository memberRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    /**
+     * 10분마다 실행 - 탑러너 선정
+     * 경험치 상위 5명 선정 후 이벤트 발행
+     */
+    @Scheduled(cron = "0 */1 * * * *")
+    public void selectTopRunners() {
+        log.info("탑러너 선정 스케줄 시작");
+
+        try {
+            // 경험치 상위 5명 조회
+            List<Member> topMembers = memberRepository.findTopMembersByExperience(PageRequest.of(0, 5));
+
+            if (topMembers.isEmpty()) {
+                log.info("탑러너 선정 대상이 없습니다");
+                return;
+            }
+
+            List<Long> memberIds = topMembers.stream()
+                    .map(Member::getId)
+                    .toList();
+
+            log.info("탑러너 선정 완료 - 선정된 회원 수: {}, memberIds: {}", memberIds.size(), memberIds);
+
+            // 탑러너 선정 이벤트 발행
+            eventPublisher.publishEvent(new TopRunnerSelectedEvent(memberIds));
+
+            log.info("탑러너 선정 이벤트 발행 완료");
+        } catch (Exception e) {
+            log.error("탑러너 선정 실패 - error: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/econovation/moongtaengi/member/application/TopRunnerScheduler.java
+++ b/src/main/java/econovation/moongtaengi/member/application/TopRunnerScheduler.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 /**
  * 탑러너 스케줄러
- * - 10분마다 경험치 상위 5명 선정
+ * - 5분마다 경험치 상위 5명 선정
  * - TopRunnerSelectedEvent 발행 (컬렉션 해금은 CollectionEventListener가 처리)
  * - 한번 해금되면 순위에서 밀려나도 회수하지 않음
  */
@@ -30,7 +30,7 @@ public class TopRunnerScheduler {
      * 10분마다 실행 - 탑러너 선정
      * 경험치 상위 5명 선정 후 이벤트 발행
      */
-    @Scheduled(cron = "0 */1 * * * *")
+    @Scheduled(cron = "0 */5 * * * *")
     public void selectTopRunners() {
         log.info("탑러너 선정 스케줄 시작");
 

--- a/src/main/java/econovation/moongtaengi/member/domain/MemberRepository.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/MemberRepository.java
@@ -1,7 +1,9 @@
 package econovation.moongtaengi.member.domain;
 
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
@@ -17,4 +19,12 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findAllByStatus(MemberStatus status);
 
     long countByStatus(MemberStatus status);
+
+    /**
+     * 경험치 상위 회원 조회
+     * @param pageable 페이징 정보 (Limit 5)
+     * @return 경험치 상위 회원 목록
+     */
+    @Query("SELECT m FROM Member m WHERE m.status = 'ACTIVE' ORDER BY m.totalExperience DESC")
+    List<Member> findTopMembersByExperience(Pageable pageable);
 }

--- a/src/main/java/econovation/moongtaengi/member/domain/event/TopRunnerSelectedEvent.java
+++ b/src/main/java/econovation/moongtaengi/member/domain/event/TopRunnerSelectedEvent.java
@@ -1,0 +1,14 @@
+package econovation.moongtaengi.member.domain.event;
+
+import java.util.List;
+
+/**
+ * 탑러너 선정 이벤트
+ * 스케줄러가 경험치 상위 회원을 선정한 후 발행
+ *
+ * @param memberIds 선정된 탑러너 회원 ID 목록
+ */
+public record TopRunnerSelectedEvent(
+        List<Long> memberIds
+) {
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/StudyMemberRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/StudyMemberRepository.java
@@ -2,6 +2,7 @@ package econovation.moongtaengi.study.domain;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -36,4 +37,13 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> 
             @Param("memberId") Long memberId,
             @Param("role") StudyRole role
     );
+
+    /**
+     * 회원이 참여 중인 스터디 중 가장 최근에 업데이트된 스터디 조회
+     * @param memberId 회원 ID
+     * @param pageable 페이징 정보 (Limit 1)
+     * @return 가장 최근 업데이트된 스터디
+     */
+    @Query("SELECT sm FROM StudyMember sm JOIN FETCH sm.study s WHERE sm.memberId = :memberId ORDER BY s.updatedAt DESC")
+    List<StudyMember> findMostRecentStudyByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 }


### PR DESCRIPTION
### 📌 PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈

### 🧑‍💻 구현한 내용
- 5분마다 경험치 TOP 5인 유저 대상으로 탑러너 선정 이벤트 발행
- 탑러너 선정 이벤트 리스너를 통해 탑러너 뭉탱이 발급
- 메인페이지 조회 API를 통해 메인페이지에 필요한 정보 및 현재 탑러너 5명의 닉네임과 프로필 아이콘을 제공함 `GET /api/home`
  - 오늘의 응원 문구 10개를 임의로 넣었으며 그 중 한개를 랜덤으로 응답으로 넣어줌
  - shortcutStudyId : 가장 최근에 수정된 스터디의 id를 제공하여 프로젝트 바로가기 버튼을 눌렀을 때 해당 스터디로 이동할 수 있게함
- 뭉탱이 URL 중 일부 잘못된게 있어서 수정함
### 🧪 테스트 결과
<img width="2006" height="1340" alt="image" src="https://github.com/user-attachments/assets/ea274cff-4102-4153-81b7-9dd343d8837d" />

### 👿 트러블 슈팅

### 💬 코멘트



