### PR TITLE
feat: 과제 제출물 수정 기능 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/api/SubmissionController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/SubmissionController.java
@@ -2,13 +2,18 @@ package econovation.moongtaengi.study.api;
 
 import econovation.moongtaengi.global.annotation.LoginMemberId;
 import econovation.moongtaengi.study.api.dto.SubmissionCreateRequest;
+import econovation.moongtaengi.study.api.dto.SubmissionUpdateRequest;
 import econovation.moongtaengi.study.application.submission.CreateSubmissionCommand;
 import econovation.moongtaengi.study.application.submission.CreateSubmissionService;
+import econovation.moongtaengi.study.application.submission.UpdateSubmissionCommand;
+import econovation.moongtaengi.study.application.submission.UpdateSubmissionService;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class SubmissionController {
 
     private final CreateSubmissionService createSubmissionService;
+    private final UpdateSubmissionService updateSubmissionService;
 
     @PostMapping
     public ResponseEntity<Void> createSubmission(
@@ -32,6 +38,19 @@ public class SubmissionController {
         Long submissionId = createSubmissionService.createSubmission(command);
 
         return ResponseEntity.created(URI.create("/api/submissions/" + submissionId)).build();
+    }
+
+    @PatchMapping("/{submissionId}")
+    public ResponseEntity<Void> updateSubmission(
+            @LoginMemberId Long requesterId,
+            @PathVariable Long submissionId,
+            @RequestBody SubmissionUpdateRequest request
+    ) {
+        UpdateSubmissionCommand command = request.toCommand(submissionId, requesterId);
+
+        updateSubmissionService.updateSubmission(command);
+
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/econovation/moongtaengi/study/api/dto/SubmissionUpdateRequest.java
+++ b/src/main/java/econovation/moongtaengi/study/api/dto/SubmissionUpdateRequest.java
@@ -1,0 +1,19 @@
+package econovation.moongtaengi.study.api.dto;
+
+import econovation.moongtaengi.study.application.submission.UpdateSubmissionCommand;
+
+public record SubmissionUpdateRequest(
+        String content,
+        String fileName,
+        String fileUrl
+) {
+    public UpdateSubmissionCommand toCommand(Long submissionId, Long requesterId) {
+        return new UpdateSubmissionCommand(
+                submissionId,
+                requesterId,
+                this.content,
+                this.fileName,
+                this.fileUrl
+        );
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/application/submission/UpdateSubmissionCommand.java
+++ b/src/main/java/econovation/moongtaengi/study/application/submission/UpdateSubmissionCommand.java
@@ -1,0 +1,11 @@
+package econovation.moongtaengi.study.application.submission;
+
+public record UpdateSubmissionCommand(
+        Long submissionId,
+        Long requesterId,
+        String content,
+        String fileName,
+        String fileUrl
+) {
+
+}

--- a/src/main/java/econovation/moongtaengi/study/application/submission/UpdateSubmissionService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/submission/UpdateSubmissionService.java
@@ -1,0 +1,38 @@
+package econovation.moongtaengi.study.application.submission;
+
+import econovation.moongtaengi.study.domain.submission.Submission;
+import econovation.moongtaengi.study.domain.submission.SubmissionAttachment;
+import econovation.moongtaengi.study.domain.submission.SubmissionContent;
+import econovation.moongtaengi.study.domain.submission.SubmissionErrorCode;
+import econovation.moongtaengi.study.domain.submission.SubmissionException;
+import econovation.moongtaengi.study.domain.submission.SubmissionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateSubmissionService {
+
+    private final SubmissionRepository submissionRepository;
+
+    @Transactional
+    public void updateSubmission(UpdateSubmissionCommand command) {
+
+        Submission submission = submissionRepository.findById(command.submissionId())
+                .orElseThrow(() -> new SubmissionException(SubmissionErrorCode.SUBMISSION_NOT_FOUND));
+
+        SubmissionContent contentToUpdate = command.content() != null
+                ? new SubmissionContent(command.content())
+                : submission.getContent();
+
+        SubmissionAttachment attachmentToUpdate = submission.getAttachment().orElse(null);
+
+        if (command.fileName() != null && command.fileUrl() != null) {
+            attachmentToUpdate = SubmissionAttachment.of(command.fileName(), command.fileUrl());
+        }
+
+        submission.update(command.requesterId(), contentToUpdate, attachmentToUpdate);
+    }
+
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/submission/Submission.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/submission/Submission.java
@@ -77,4 +77,25 @@ public class Submission extends BaseEntity {
             throw new SubmissionException(SubmissionErrorCode.CREATE_ARGUMENT_MISSING);
         }
     }
+
+    public void update(Long requesterId, SubmissionContent content, SubmissionAttachment attachment) {
+        validateOwner(requesterId);
+        validateUpdatable(content);
+        this.content = content;
+        this.attachment = attachment;
+    }
+
+    private void validateUpdatable(SubmissionContent content) {
+        if (content == null) {
+            throw new SubmissionException(SubmissionErrorCode.INVALID_SUBMISSION_INFO);
+        }
+    }
+
+    private void validateOwner(Long requesterId) {
+        if (!this.submitterId.equals(requesterId)) {
+            throw new SubmissionException(SubmissionErrorCode.NOT_SUBMISSION_OWNER);
+        }
+    }
+
+
 }

--- a/src/main/java/econovation/moongtaengi/study/domain/submission/SubmissionErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/submission/SubmissionErrorCode.java
@@ -22,7 +22,9 @@ public enum SubmissionErrorCode implements ErrorCode {
 
     INVALID_ASSIGNMENT_ID(HttpStatus.NOT_FOUND, "SM_007", "유효하지 않은 과제 ID 입니다."),
 
-    NOT_ASSIGNEE(HttpStatus.FORBIDDEN, "SM_008", "해당 과제의 담당자가 아닙니다.");
+    NOT_ASSIGNEE(HttpStatus.FORBIDDEN, "SM_008", "해당 과제의 담당자가 아닙니다."),
+
+    NOT_SUBMISSION_OWNER(HttpStatus.FORBIDDEN, "SM_009", "제출물 수정 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/econovation/moongtaengi/study/domain/submission/SubmissionErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/submission/SubmissionErrorCode.java
@@ -24,7 +24,9 @@ public enum SubmissionErrorCode implements ErrorCode {
 
     NOT_ASSIGNEE(HttpStatus.FORBIDDEN, "SM_008", "해당 과제의 담당자가 아닙니다."),
 
-    NOT_SUBMISSION_OWNER(HttpStatus.FORBIDDEN, "SM_009", "제출물 수정 권한이 없습니다.");
+    NOT_SUBMISSION_OWNER(HttpStatus.FORBIDDEN, "SM_009", "제출물 수정 권한이 없습니다."),
+
+    SUBMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SM_0010", "존재하지 않는 제출물입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/test/java/econovation/moongtaengi/study/api/SubmissionControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/SubmissionControllerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -14,8 +15,11 @@ import econovation.moongtaengi.global.config.WebConfig;
 import econovation.moongtaengi.global.security.CustomAuthentication;
 import econovation.moongtaengi.global.security.LoginMemberIdArgumentResolver;
 import econovation.moongtaengi.study.api.dto.SubmissionCreateRequest;
+import econovation.moongtaengi.study.api.dto.SubmissionUpdateRequest;
 import econovation.moongtaengi.study.application.submission.CreateSubmissionCommand;
 import econovation.moongtaengi.study.application.submission.CreateSubmissionService;
+import econovation.moongtaengi.study.application.submission.UpdateSubmissionCommand;
+import econovation.moongtaengi.study.application.submission.UpdateSubmissionService;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +53,9 @@ public class SubmissionControllerTest {
 
     @MockitoBean
     private CreateSubmissionService createSubmissionService;
+
+    @MockitoBean
+    private UpdateSubmissionService updateSubmissionService;
 
     @BeforeEach
     void setUp() {
@@ -115,5 +122,35 @@ public class SubmissionControllerTest {
                 Arguments.of("내용 누락(빈 문자열)", 1L, ""),
                 Arguments.of("내용 누락(공백)", 1L, "   ")
         );
+    }
+
+    @Test
+    @DisplayName("과제 수정 요청이 오면 200 OK를 반환하고 서비스에 올바른 명령을 전달한다")
+    void 과제_수정_성공() throws Exception {
+        //given
+        Long submissionId = 1L;
+        Long requesterId = 1L;
+
+        SubmissionUpdateRequest request = new SubmissionUpdateRequest(
+                "수정된 내용",
+                "new.pdf",
+                "http://new-url.com"
+        );
+
+        //when&then
+        mvc.perform(patch("/api/submissions/{submissionId}", submissionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk());
+        ArgumentCaptor<UpdateSubmissionCommand> commandCaptor = ArgumentCaptor.forClass(UpdateSubmissionCommand.class);
+        verify(updateSubmissionService).updateSubmission(commandCaptor.capture());
+
+        UpdateSubmissionCommand passedCommand = commandCaptor.getValue();
+
+        assertThat(passedCommand.submissionId()).isEqualTo(submissionId);
+        assertThat(passedCommand.requesterId()).isEqualTo(requesterId);
+        assertThat(passedCommand.content()).isEqualTo(request.content());
+        assertThat(passedCommand.fileName()).isEqualTo(request.fileName());
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/application/UpdateSubmissionServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/UpdateSubmissionServiceTest.java
@@ -1,0 +1,128 @@
+package econovation.moongtaengi.study.application;
+
+import static econovation.moongtaengi.study.domain.submission.SubmissionFixture.DEFAULT_ATTACHMENT;
+import static econovation.moongtaengi.study.domain.submission.SubmissionFixture.DEFAULT_CONTENT;
+import static econovation.moongtaengi.study.domain.submission.SubmissionFixture.DEFAULT_SUBMITTER_ID;
+import static econovation.moongtaengi.study.domain.submission.SubmissionFixture.aSubmission;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import econovation.moongtaengi.study.application.submission.UpdateSubmissionCommand;
+import econovation.moongtaengi.study.application.submission.UpdateSubmissionService;
+import econovation.moongtaengi.study.domain.submission.Submission;
+import econovation.moongtaengi.study.domain.submission.SubmissionException;
+import econovation.moongtaengi.study.domain.submission.SubmissionRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class UpdateSubmissionServiceTest {
+
+    @Mock
+    private SubmissionRepository submissionRepository;
+
+    @InjectMocks
+    private UpdateSubmissionService updateSubmissionService;
+
+    @Test
+    @DisplayName("내용과 첨부파일이 모두 주어지면 둘 다 수정된다")
+    void 과제_수정_성공_전체수정() {
+        //given
+        Long submissionId = 1L;
+        Submission submission = aSubmission().build();
+        ReflectionTestUtils.setField(submission, "id", submissionId);
+
+        UpdateSubmissionCommand command = new UpdateSubmissionCommand(
+                submissionId,
+                DEFAULT_SUBMITTER_ID,
+                "완전 수정됨",
+                "new.pdf",
+                "http://new.com"
+        );
+
+        given(submissionRepository.findById(submissionId)).willReturn(Optional.of(submission));
+
+        //when
+        updateSubmissionService.updateSubmission(command);
+
+        //then
+        assertThat(submission.getContent().getValue()).isEqualTo("완전 수정됨");
+        assertThat(submission.getAttachment().get().getName()).isEqualTo("new.pdf");
+    }
+
+    @Test
+    @DisplayName("첨부파일 정보가 Null이면 기존 첨부파일이 유지된다 (삭제되지 않음)")
+    void 과제_수정_성공_파일유지() {
+        //given
+        Long submissionId = 1L;
+        Submission submission = aSubmission().build();
+        ReflectionTestUtils.setField(submission, "id", submissionId);
+
+        UpdateSubmissionCommand command = new UpdateSubmissionCommand(
+                submissionId,
+                DEFAULT_SUBMITTER_ID,
+                "내용만 바꿈",
+                null,
+                null
+        );
+
+        given(submissionRepository.findById(submissionId)).willReturn(Optional.of(submission));
+
+        //when
+        updateSubmissionService.updateSubmission(command);
+
+        //then
+        assertThat(submission.getContent().getValue()).isEqualTo("내용만 바꿈");
+        assertThat(submission.getAttachment()).isPresent();
+        assertThat(submission.getAttachment().get().getName()).isEqualTo(DEFAULT_ATTACHMENT.getName());
+    }
+
+    @Test
+    @DisplayName("내용이 Null이면 기존 내용이 유지된다")
+    void 과제_수정_성공_내용유지() {
+        //given
+        Long submissionId = 1L;
+        Submission submission = aSubmission().build();
+        ReflectionTestUtils.setField(submission, "id", submissionId);
+
+        UpdateSubmissionCommand command = new UpdateSubmissionCommand(
+                submissionId,
+                DEFAULT_SUBMITTER_ID,
+                null,
+                "only_file.pdf",
+                "http://only.com"
+        );
+
+        given(submissionRepository.findById(submissionId)).willReturn(Optional.of(submission));
+
+        //when
+        updateSubmissionService.updateSubmission(command);
+
+        //then
+        assertThat(submission.getContent().getValue()).isEqualTo(DEFAULT_CONTENT.getValue());
+        assertThat(submission.getAttachment().get().getName()).isEqualTo("only_file.pdf");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 과제 ID면 예외가 발생한다")
+    void 과제_수정_실패_미존재() {
+        //given
+        Long invalidId = 999L;
+        UpdateSubmissionCommand command = new UpdateSubmissionCommand(
+                invalidId, DEFAULT_SUBMITTER_ID, "content", "file", "url"
+        );
+
+        given(submissionRepository.findById(invalidId)).willReturn(Optional.empty());
+
+        //when&then
+        assertThatThrownBy(() -> updateSubmissionService.updateSubmission(command))
+                .isInstanceOf(SubmissionException.class);
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/submission/SubmissionTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/submission/SubmissionTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
-import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -112,6 +111,85 @@ public class SubmissionTest {
         Collection<Object> events = submission.domainEvents();
         assertThat(events).hasSize(1);
         assertThat(((SubmissionCreatedEvent) events.iterator().next()).isLate()).isFalse();
+    }
+
+    @Test
+    @DisplayName("제출물의 내용과 첨부파일을 수정할 수 있다")
+    void 제출물_수정_성공() {
+        //given
+        Long submitterId = 1L;
+        Submission submission = aSubmission()
+                .submitterId(submitterId)
+                .build();
+
+        SubmissionContent newContent = new SubmissionContent("수정된 내용");
+        SubmissionAttachment newAttachment = SubmissionAttachment.of("new.pdf", "https://new-url.com");
+
+        //when
+        submission.update(submitterId, newContent, newAttachment);
+
+        //then
+        assertThat(submission.getContent()).isEqualTo(newContent);
+        assertThat(submission.getAttachment()).isPresent();
+        assertThat(submission.getAttachment().get().getName()).isEqualTo("new.pdf");
+        assertThat(submission.getAttachment().get().getUrl()).isEqualTo("https://new-url.com");
+    }
+
+    @Test
+    @DisplayName("첨부파일을 null로 업데이트하면 첨부파일이 삭제된다")
+    void 제출물_수정_첨부파일_삭제() {
+        //given
+        Long submitterId = 1L;
+        Submission submission = aSubmission()
+                .submitterId(submitterId)
+                .build();
+
+        SubmissionContent newContent = new SubmissionContent("첨부파일 삭제함");
+
+        //when
+        submission.update(submitterId, newContent, null);
+
+        //then
+        assertThat(submission.getContent()).isEqualTo(newContent);
+        assertThat(submission.getAttachment()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("수정 시 내용은 필수이므로 null이 들어오면 예외가 발생한다")
+    void 제출물_수정_실패_내용누락() {
+        //given
+        Long submitterId = 1L;
+        Submission submission = aSubmission()
+                .submitterId(submitterId)
+                .build();
+
+        //when&then
+        assertThatThrownBy(() -> submission.update(submitterId,  null, null))
+                .isInstanceOf(SubmissionException.class)
+                .extracting("errorCode")
+                .isEqualTo(SubmissionErrorCode.INVALID_SUBMISSION_INFO);
+    }
+
+    @Test
+    @DisplayName("작성자가 아닌 사람이 수정을 시도하면 예외가 발생한다")
+    void 제출물_수정_실패_작성자_불일치() {
+        //given
+        Long submitterId = 1L;
+        Long otherUserId = 999L;
+
+        Submission submission = aSubmission()
+                .submitterId(submitterId)
+                .build();
+
+        SubmissionContent newContent = new SubmissionContent("다른 사람이지롱~");
+
+        //when&then
+        assertThatThrownBy(() ->
+                submission.update(otherUserId, newContent, null)
+        )
+                .isInstanceOf(SubmissionException.class)
+                .extracting("errorCode")
+                .isEqualTo(SubmissionErrorCode.NOT_SUBMISSION_OWNER);
     }
 }
 


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
**1. Domain Layer (`Submission` Entity)**
- 수정 로직 구현: `update()` 메서드를 통해 내용과 첨부파일을 갱신.
- 검증 로직:
  - 소유권 검증: 요청자(`requesterId`)와 작성자(`submitterId`)가 일치하지 않을 경우 `NOT_SUBMISSION_OWNER` 예외를 발생.
  - 불변식 보호: 수정 시 `content`는 필수 값이므로 `null` 유입 시 예외 처리.
- 첨부파일 처리 정책: Entity 레벨에서는 `attachment` 인자로 `null`이 전달되면 기존 파일을 삭제하는 것으로 간주. 

**2. Application Layer (`UpdateSubmissionService`)**
- PATCH 전략 적용: DTO의 필드가 `null`인 경우 기존 데이터를 유지하고, 값이 있는 경우에만 변경하도록 구현.
  - 이를 통해 프론트엔드에서 변경하지 않은 필드를 누락하더라도 데이터가 유실되지 않도록 함.
- 첨부파일 갱신:`Optional`을 활용하여 기존 파일의 유무와 상관없이, 새로운 파일 정보가 들어온 경우에만 교체 로직을 수행.
- 트랜잭션 보장: `@Transactional`을 적용하여 Dirty Checking을 통한 업데이트를 보장.

**3. Presentation Layer (`SubmissionController`, `DTO`)**
- API Endpoint:`PATCH /api/submissions/{submissionId}` 엔드포인트를 구현.
- DTO 캡슐화:`SubmissionUpdateRequest` (Record) 내부에 `toCommand(id, requesterId)` 메서드를 구현.

**4. Error Codes**
- `NOT_SUBMISSION_OWNER` (403): 작성자 불일치 시
- `SUBMISSION_NOT_FOUND` (404): 존재하지 않는 제출물 조회 시

**Domain Test (`SubmissionTest`)**
- 수정 시 내용/첨부파일 변경 확인
- 작성자 불일치 시 예외 발생 확인
- 내용 누락 시 예외 발생 확인

**Service Test (`UpdateSubmissionServiceTest`)**
- 내용만 수정, 첨부파일만 수정, 전체 수정 시나리오 검증
- DTO 필드가 `null`일 때 기존 값이 유지되는지 검증
- 존재하지 않는 ID 조회 시 예외 검증

**Controller Test (`SubmissionControllerTest`)**
- `MockMvc`를 이용한 PATCH 요청 테스트
- JSON Body 매핑 및 Service 호출 파라미터 검증
### 🧪 테스트 결과
- [x] 테스트 코드 모두 통과했습니다! 
- [x] 포스트맨 이용 테스트
<img width="671" height="449" alt="image" src="https://github.com/user-attachments/assets/0c3979ae-a559-4c9e-bdc9-310838c9769b" />
<img width="671" height="373" alt="image" src="https://github.com/user-attachments/assets/5a3a9f6d-5f4a-494c-9810-2028238fdb91" />
<img width="671" height="409" alt="image" src="https://github.com/user-attachments/assets/2018dd6a-0ab8-4b58-84bf-ce46e1950bb7" />
 
### 👿 트러블 슈팅

### 💬 코멘트



