### PR TITLE
feat: 탑러너 조회 API 구현

### DIFF
--- a/src/main/java/econovation/moongtaengi/global/security/config/SecurityConfig.java
+++ b/src/main/java/econovation/moongtaengi/global/security/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/auth/kakao/callback",
                                 "/api/members/check-nickname",
+                                "/api/home/top-runners",  // 탑러너 목록 (공개 API)
                                 "/admin/login",           // 관리자 로그인 페이지
                                 "/admin/do-login",
                                 "/admin/login-success",

--- a/src/main/java/econovation/moongtaengi/home/api/HomeController.java
+++ b/src/main/java/econovation/moongtaengi/home/api/HomeController.java
@@ -2,6 +2,7 @@ package econovation.moongtaengi.home.api;
 
 import econovation.moongtaengi.global.annotation.LoginMemberId;
 import econovation.moongtaengi.home.api.dto.HomeResponse;
+import econovation.moongtaengi.home.api.dto.TopRunnerListResponse;
 import econovation.moongtaengi.home.application.HomeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +33,18 @@ public class HomeController {
         log.info("메인 페이지 조회 API 호출 - memberId: {}", memberId);
 
         HomeResponse response = homeService.getHomeInfo(memberId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 탑러너 목록 조회 (공개 API)
+     * @return 경험치 상위 5명의 탑러너 목록
+     */
+    @GetMapping("/top-runners")
+    public ResponseEntity<TopRunnerListResponse> getTopRunners() {
+        log.info("탑러너 목록 조회 API 호출 (공개)");
+
+        TopRunnerListResponse response = new TopRunnerListResponse(homeService.getTopRunners());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/econovation/moongtaengi/home/api/dto/HomeResponse.java
+++ b/src/main/java/econovation/moongtaengi/home/api/dto/HomeResponse.java
@@ -1,7 +1,5 @@
 package econovation.moongtaengi.home.api.dto;
 
-import java.util.List;
-
 /**
  * 메인 페이지 응답
  * @param nickname 사용자 닉네임
@@ -14,7 +12,6 @@ import java.util.List;
  * @param collectionCount 보유 컬렉션 수
  * @param totalExperience 총 경험치
  * @param shortcutStudyId 바로가기 스터디 ID (없으면 null)
- * @param topRunners 탑러너 목록 (최대 5명)
  */
 public record HomeResponse(
         String nickname,
@@ -26,7 +23,6 @@ public record HomeResponse(
         String activityTitle,
         Long collectionCount,
         int totalExperience,
-        Long shortcutStudyId,
-        List<TopRunnerInfo> topRunners
+        Long shortcutStudyId
 ) {
 }

--- a/src/main/java/econovation/moongtaengi/home/api/dto/TopRunnerListResponse.java
+++ b/src/main/java/econovation/moongtaengi/home/api/dto/TopRunnerListResponse.java
@@ -1,0 +1,12 @@
+package econovation.moongtaengi.home.api.dto;
+
+import java.util.List;
+
+/**
+ * 탑러너 목록 응답
+ * @param topRunners 탑러너 목록 (최대 5명)
+ */
+public record TopRunnerListResponse(
+        List<TopRunnerInfo> topRunners
+) {
+}

--- a/src/main/java/econovation/moongtaengi/home/application/HomeService.java
+++ b/src/main/java/econovation/moongtaengi/home/application/HomeService.java
@@ -75,16 +75,6 @@ public class HomeService {
                 .map(study -> study.getId())
                 .orElse(null);
 
-        // 탑러너 목록 조회
-        List<TopRunnerInfo> topRunners = memberRepository
-                .findTopMembersByExperience(PageRequest.of(0, 5))
-                .stream()
-                .map(topMember -> new TopRunnerInfo(
-                        topMember.getNickname().getValue(),
-                        topMember.getProfileIcon().getUnlockedImageUrl()
-                ))
-                .toList();
-
         log.info("회원 {}의 메인 페이지 정보를 조회했습니다", memberId);
 
         return new HomeResponse(
@@ -97,8 +87,27 @@ public class HomeService {
                 member.getTitle().getDisplayName(),
                 collectionCount,
                 member.getTotalExperience(),
-                shortcutStudyId,
-                topRunners
+                shortcutStudyId
         );
+    }
+
+    /**
+     * 탑러너 목록 조회 (공개 API)
+     * @return 경험치 상위 5명의 탑러너 목록
+     */
+    public List<TopRunnerInfo> getTopRunners() {
+        log.info("탑러너 목록을 조회합니다");
+
+        List<TopRunnerInfo> topRunners = memberRepository
+                .findTopMembersByExperience(PageRequest.of(0, 5))
+                .stream()
+                .map(topMember -> new TopRunnerInfo(
+                        topMember.getNickname().getValue(),
+                        topMember.getProfileIcon().getUnlockedImageUrl()
+                ))
+                .toList();
+
+        log.info("탑러너 목록 조회 완료 - {} 명", topRunners.size());
+        return topRunners;
     }
 }


### PR DESCRIPTION
### 📌 PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈

### 🧑‍💻 구현한 내용
- 기존 메인페이지 조회 API에서 탑러너 조회 기능을 분리했습니다.
- 탑러너 조회 API는 인증 필요 없어도 되게 구현했습니다.
`GET /api/home/top-runners`

### 🧪 테스트 결과
<img width="1994" height="1254" alt="image" src="https://github.com/user-attachments/assets/cbf428ac-8acf-450c-9c98-3ad6dcba666b" />

### 👿 트러블 슈팅

### 💬 코멘트



