### PR TITLE
feat: 제출물에 대한 댓글 목록 조회 기능 추가

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/api/CommentController.java
+++ b/src/main/java/econovation/moongtaengi/study/api/CommentController.java
@@ -3,14 +3,18 @@ package econovation.moongtaengi.study.api;
 import econovation.moongtaengi.global.annotation.LoginMemberId;
 import econovation.moongtaengi.study.api.dto.CommentCreateRequest;
 import econovation.moongtaengi.study.api.dto.CommentUpdateRequest;
+import econovation.moongtaengi.study.application.comment.CommentQueryService;
+import econovation.moongtaengi.study.application.comment.CommentSummary;
 import econovation.moongtaengi.study.application.comment.CreateCommentCommand;
 import econovation.moongtaengi.study.application.comment.CreateCommentService;
 import econovation.moongtaengi.study.application.comment.UpdateCommentService;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -26,6 +30,7 @@ public class CommentController {
 
     private final CreateCommentService createCommentService;
     private final UpdateCommentService updateCommentService;
+    private final CommentQueryService commentQueryService;
 
     @PostMapping("/submissions/{submissionId}/comments")
     public ResponseEntity<Void> createComment(
@@ -40,6 +45,15 @@ public class CommentController {
         Long commentId = createCommentService.createComment(command);
 
         return ResponseEntity.created(URI.create("/api/comments/" + commentId)).build();
+    }
+
+    @GetMapping("/submissions/{submissionId}/comments")
+    public ResponseEntity<List<CommentSummary>> getComments(
+            @PathVariable Long submissionId,
+            @LoginMemberId Long memberId
+    ) {
+        List<CommentSummary> response = commentQueryService.getComments(submissionId, memberId);
+        return ResponseEntity.ok(response);
     }
 
     @PutMapping("/comments/{commentId}")

--- a/src/main/java/econovation/moongtaengi/study/application/comment/CommentQueryService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/comment/CommentQueryService.java
@@ -1,0 +1,27 @@
+package econovation.moongtaengi.study.application.comment;
+
+import econovation.moongtaengi.study.domain.comment.CommentMemberValidator;
+import econovation.moongtaengi.study.domain.comment.CommentRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentQueryService {
+
+    private final CommentRepository commentRepository;
+    private final CommentMemberValidator commentMemberValidator;
+
+    public List<CommentSummary> getComments(Long submissionId, Long loginMemberId) {
+        commentMemberValidator.validate(loginMemberId, submissionId);
+
+        return commentRepository.findRawListBySubmissionId(submissionId).stream()
+                .map(raw -> CommentSummary.of(loginMemberId, raw))
+                .toList();
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/application/comment/CommentSummary.java
+++ b/src/main/java/econovation/moongtaengi/study/application/comment/CommentSummary.java
@@ -16,10 +16,10 @@ public record CommentSummary(
     public static CommentSummary of(Long loginMemberId, CommentSummaryRaw raw) {
         return new CommentSummary(
                 raw.commentId(),
-                raw.content(),
+                nullToEmpty(raw.content()),
                 raw.createdAt(),
                 raw.memberId(),
-                raw.nickname(),
+                nullToEmpty(raw.nickname()),
                 getProfileIconUrl(raw.profileIcon()),
                 isMyComment(loginMemberId, raw.memberId())
         );
@@ -34,5 +34,9 @@ public record CommentSummary(
 
     private static boolean isMyComment(Long loginMemberId, Long writerId) {
         return loginMemberId != null && loginMemberId.equals(writerId);
+    }
+
+    private static String nullToEmpty(String value) {
+        return value == null ? "" : value;
     }
 }

--- a/src/main/java/econovation/moongtaengi/study/application/comment/CommentSummary.java
+++ b/src/main/java/econovation/moongtaengi/study/application/comment/CommentSummary.java
@@ -1,0 +1,38 @@
+package econovation.moongtaengi.study.application.comment;
+
+import econovation.moongtaengi.collection.domain.CollectionType;
+import econovation.moongtaengi.study.domain.comment.CommentSummaryRaw;
+import java.time.LocalDateTime;
+
+public record CommentSummary(
+        Long commentId,
+        String content,
+        LocalDateTime createdAt,
+        Long memberId,
+        String nickname,
+        String profileImageUrl,
+        boolean isMyComment
+) {
+    public static CommentSummary of(Long loginMemberId, CommentSummaryRaw raw) {
+        return new CommentSummary(
+                raw.commentId(),
+                raw.content(),
+                raw.createdAt(),
+                raw.memberId(),
+                raw.nickname(),
+                getProfileIconUrl(raw.profileIcon()),
+                isMyComment(loginMemberId, raw.memberId())
+        );
+    }
+
+    private static String getProfileIconUrl(CollectionType type) {
+        if (type == null) {
+            return CollectionType.DEFAULT.getUnlockedImageUrl();
+        }
+        return type.getUnlockedImageUrl();
+    }
+
+    private static boolean isMyComment(Long loginMemberId, Long writerId) {
+        return loginMemberId != null && loginMemberId.equals(writerId);
+    }
+}

--- a/src/main/java/econovation/moongtaengi/study/domain/comment/CommentRepository.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/comment/CommentRepository.java
@@ -1,8 +1,27 @@
 package econovation.moongtaengi.study.domain.comment;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     long countByMemberId(Long memberId);
+
+    @Query("""
+        SELECT new econovation.moongtaengi.study.domain.comment.CommentSummaryRaw(
+            c.id,
+            c.content.value,
+            c.createdAt,
+            m.id,
+            m.nickname.value,
+            m.profileIcon
+        )
+        FROM Comment c
+        JOIN Member m ON c.memberId = m.id
+        WHERE c.submissionId = :submissionId
+        ORDER BY c.createdAt ASC
+    """)
+    List<CommentSummaryRaw> findRawListBySubmissionId(@Param("submissionId") Long submissionId);
 }

--- a/src/main/java/econovation/moongtaengi/study/domain/comment/CommentSummaryRaw.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/comment/CommentSummaryRaw.java
@@ -1,0 +1,15 @@
+package econovation.moongtaengi.study.domain.comment;
+
+import econovation.moongtaengi.collection.domain.CollectionType;
+import java.time.LocalDateTime;
+
+public record CommentSummaryRaw(
+        Long commentId,
+        String content,
+        LocalDateTime createdAt,
+        Long memberId,
+        String nickname,
+        CollectionType profileIcon
+) {
+
+}

--- a/src/test/java/econovation/moongtaengi/study/api/CommentControllerTest.java
+++ b/src/test/java/econovation/moongtaengi/study/api/CommentControllerTest.java
@@ -3,9 +3,11 @@ package econovation.moongtaengi.study.api;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,10 +16,14 @@ import econovation.moongtaengi.global.security.CustomAuthentication;
 import econovation.moongtaengi.global.security.LoginMemberIdArgumentResolver;
 import econovation.moongtaengi.study.api.dto.CommentCreateRequest;
 import econovation.moongtaengi.study.api.dto.CommentUpdateRequest;
+import econovation.moongtaengi.study.application.comment.CommentQueryService;
+import econovation.moongtaengi.study.application.comment.CommentSummary;
 import econovation.moongtaengi.study.application.comment.CreateCommentCommand;
 import econovation.moongtaengi.study.application.comment.CreateCommentService;
 import econovation.moongtaengi.study.application.comment.UpdateCommentCommand;
 import econovation.moongtaengi.study.application.comment.UpdateCommentService;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,6 +53,9 @@ public class CommentControllerTest {
 
     @MockitoBean
     private UpdateCommentService updateCommentService;
+
+    @MockitoBean
+    private CommentQueryService commentQueryService;
 
     @BeforeEach
     void setUp() {
@@ -96,5 +105,37 @@ public class CommentControllerTest {
                 .andExpect(status().isOk());
 
         verify(updateCommentService).updateComment(expectedCommand);
+    }
+
+    @Test
+    @DisplayName("제출물 댓글 목록 조회 요청 시 200 OK와 댓글 리스트를 반환한다.")
+    void 댓글_목록_조회_성공() throws Exception {
+        //given
+        Long submissionId = 100L;
+        Long loginMemberId = 1L;
+
+        CommentSummary summary = new CommentSummary(
+                10L,
+                "조회된 댓글 내용",
+                LocalDateTime.now(),
+                1L,
+                "지환",
+                "https://icon.url",
+                true
+        );
+
+        given(commentQueryService.getComments(submissionId, loginMemberId))
+                .willReturn(List.of(summary));
+
+        //when&then
+        mockMvc.perform(get("/api/submissions/{submissionId}/comments", submissionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].content").value("조회된 댓글 내용"))
+                .andExpect(jsonPath("$[0].nickname").value("지환"))
+                .andExpect(jsonPath("$[0].isMyComment").value(true));
+
+        verify(commentQueryService).getComments(submissionId, loginMemberId);
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/application/CommentQueryServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/CommentQueryServiceTest.java
@@ -1,0 +1,87 @@
+package econovation.moongtaengi.study.application;
+
+import econovation.moongtaengi.collection.domain.CollectionType;
+import econovation.moongtaengi.study.application.comment.CommentQueryService;
+import econovation.moongtaengi.study.application.comment.CommentSummary;
+import econovation.moongtaengi.study.domain.comment.CommentErrorCode;
+import econovation.moongtaengi.study.domain.comment.CommentException;
+import econovation.moongtaengi.study.domain.comment.CommentMemberValidator;
+import econovation.moongtaengi.study.domain.comment.CommentRepository;
+import econovation.moongtaengi.study.domain.comment.CommentSummaryRaw;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CommentQueryServiceTest {
+
+    @InjectMocks
+    private CommentQueryService commentQueryService;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private CommentMemberValidator commentMemberValidator;
+
+    @Test
+    @DisplayName("스터디원이 아니면 댓글 목록 조회가 불가능하고 예외가 발생해야 한다.")
+    void 스터디원이_아닌_경우_조회_실패() {
+        //given
+        Long submissionId = 100L;
+        Long outsiderId = 999L;
+
+        willThrow(new CommentException(CommentErrorCode.NO_PERMISSION))
+                .given(commentMemberValidator)
+                .validate(outsiderId, submissionId);
+
+        //when&then
+        assertThatThrownBy(() -> commentQueryService.getComments(submissionId, outsiderId))
+                .isInstanceOf(CommentException.class)
+                .extracting("errorCode")
+                .isEqualTo(CommentErrorCode.NO_PERMISSION);
+
+        verify(commentRepository, never()).findRawListBySubmissionId(any());
+    }
+
+    @Test
+    @DisplayName("스터디원이면 검증을 통과하고 댓글 목록을 조회한다.")
+    void 스터디원_검증_통과_및_조회_성공() {
+        // given
+        Long submissionId = 100L;
+        Long memberId = 1L;
+
+        CommentSummaryRaw raw = new CommentSummaryRaw(
+                10L, "테스트 댓글", LocalDateTime.now(),
+                1L, "지환", CollectionType.DEFAULT
+        );
+
+        willDoNothing().given(commentMemberValidator).validate(memberId, submissionId);
+
+        given(commentRepository.findRawListBySubmissionId(submissionId))
+                .willReturn(List.of(raw));
+
+        //when
+        List<CommentSummary> result = commentQueryService.getComments(submissionId, memberId);
+
+        //then
+        assertThat(result).hasSize(1);
+
+        verify(commentMemberValidator).validate(memberId, submissionId);
+        verify(commentRepository).findRawListBySubmissionId(submissionId);
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/application/CommentSummaryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/CommentSummaryTest.java
@@ -62,6 +62,29 @@ public class CommentSummaryTest {
         assertThat(summary.profileImageUrl()).isEqualTo(CollectionType.DEFAULT.getUnlockedImageUrl());
     }
 
+    @Test
+    @DisplayName("댓글 내용이나 닉네임이 null이면 빈 문자열로 변환되어야 한다.")
+    void 내용_및_닉네임_null_방어_로직_성공() {
+        //given
+        Long loginMemberId = 1L;
+
+        CommentSummaryRaw raw = new CommentSummaryRaw(
+                10L,
+                null,
+                LocalDateTime.now(),
+                1L,
+                null,
+                CollectionType.DEFAULT
+        );
+
+        //when
+        CommentSummary summary = CommentSummary.of(loginMemberId, raw);
+
+        //then
+        assertThat(summary.content()).isNotNull().isEmpty();
+        assertThat(summary.nickname()).isNotNull().isEmpty();
+    }
+
     private CommentSummaryRaw createRaw(Long writerId, CollectionType type) {
         return new CommentSummaryRaw(
                 10L,

--- a/src/test/java/econovation/moongtaengi/study/application/CommentSummaryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/CommentSummaryTest.java
@@ -1,0 +1,75 @@
+package econovation.moongtaengi.study.application;
+
+import econovation.moongtaengi.collection.domain.CollectionType;
+import econovation.moongtaengi.study.application.comment.CommentSummary;
+import econovation.moongtaengi.study.domain.comment.CommentSummaryRaw;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommentSummaryTest {
+
+    @Test
+    @DisplayName("로그인한 사용자가 작성자인 경우 isMyComment는 true여야 한다.")
+    void 본인_댓글_판별_성공() {
+        //given
+        Long loginMemberId = 1L;
+        Long writerId = 1L;
+
+        CommentSummaryRaw raw = createRaw(writerId, CollectionType.KANE);
+
+        //when
+        CommentSummary summary = CommentSummary.of(loginMemberId, raw);
+
+        //then
+        assertThat(summary.isMyComment()).isTrue();
+        assertThat(summary.memberId()).isEqualTo(writerId);
+        assertThat(summary.profileImageUrl()).isEqualTo(CollectionType.KANE.getUnlockedImageUrl());
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자와 작성자가 다른 경우 isMyComment는 false여야 한다.")
+    void 타인_댓글_판별_성공() {
+        //given
+        Long loginMemberId = 1L;
+        Long writerId = 2L;
+
+        CommentSummaryRaw raw = createRaw(writerId, CollectionType.KANE);
+
+        // when
+        CommentSummary summary = CommentSummary.of(loginMemberId, raw);
+
+        // then
+        assertThat(summary.isMyComment()).isFalse();
+    }
+
+
+    @Test
+    @DisplayName("프로필 아이콘 정보가 없으면(null) 기본 이미지 URL을 반환해야 한다.")
+    void 프로필_이미지_null일시_기본_URL_반환_성공() {
+        // given
+        Long loginMemberId = 1L;
+
+        CommentSummaryRaw raw = createRaw(1L, null);
+
+        // when
+        CommentSummary summary = CommentSummary.of(loginMemberId, raw);
+
+        // then
+        assertThat(summary.profileImageUrl()).isEqualTo(CollectionType.DEFAULT.getUnlockedImageUrl());
+    }
+
+    private CommentSummaryRaw createRaw(Long writerId, CollectionType type) {
+        return new CommentSummaryRaw(
+                10L,
+                "테스트 내용",
+                LocalDateTime.now(),
+                writerId,
+                "닉네임",
+                type
+        );
+    }
+}

--- a/src/test/java/econovation/moongtaengi/study/domain/comment/CommentRepositoryTest.java
+++ b/src/test/java/econovation/moongtaengi/study/domain/comment/CommentRepositoryTest.java
@@ -1,0 +1,46 @@
+package econovation.moongtaengi.study.domain.comment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import econovation.moongtaengi.member.domain.Member;
+import econovation.moongtaengi.member.domain.Nickname;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+public class CommentRepositoryTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    void 제출물_댓글_목록_String_프로젝션_조회_성공() {
+        //given
+        Member member = Member.createMember("KAKAO_", new Nickname("지환"));
+        em.persist(member);
+
+        CommentContent contentVO = new CommentContent("댓글1");
+        Comment comment = Comment.create(1L, member.getId(), contentVO);
+
+        em.persist(comment);
+        em.flush();
+        em.clear();
+
+        //when
+        List<CommentSummaryRaw> result = commentRepository.findRawListBySubmissionId(1L);
+
+        //then
+        assertThat(result).hasSize(1);
+
+        CommentSummaryRaw raw = result.get(0);
+
+        assertThat(raw.content()).isEqualTo("댓글1");
+        assertThat(raw.nickname()).isEqualTo("지환");
+    }
+}


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
1. Repository & Data Access
- Flat DTO Projection 적용: 엔티티(`Comment`) 조회 대신 JPQL `new` 오퍼레이션으로 `CommentSummaryRaw` 바로 조회.
    - 목적: 불필요한 영속화 비용 제거 및 N+1 문제 방지.
- Member Join: 작성자 정보(Member)와 Ad-hoc Join을 수행하여 쿼리 한 번으로 조회 완료함.

2. Application
- 권한 검증 분리: `CommentMemberValidator`를 통한 조회 전 스터디원 권한 검증 수행.
- 응답 DTO 책임 강화:`CommentSummary.of()` 팩토리 메서드에 View 로직 캡슐화.
    - `isMyComment`: 본인 댓글 여부 판별.
    - `profileImageUrl`: `CollectionType` Enum -> URL 변환.
    -  Null Safety: `content`, `nickname` 필드가 `null`일 경우 빈 문자열(`""`)로 치환하여 클라이언트 에러 방지.

3.Presentation
- `GET /api/submissions/{submissionId}/comments` 구현.
- `@LoginMemberId`로 인증된 사용자 ID 주입받아 처리함.

4. Test
- Repository Test : JPQL Projection 매핑 및 Member 조인 검증.
- Service Test: Validator 호출 및 예외 처리, DTO 변환 흐름 검증.
- DTO Test: `isMyComment` 판별 및 URL 변환 로직(`null` 처리 포함) 검증.
- Controller Test : API 상태 코드(200) 및 JSON 응답 필드 검증.
### 🧪 테스트 결과
- [x] 테스트 코드 모두 완료했습니다! 
- [x] 포스트맨 이용한 테스트
<img width="672" height="315" alt="image" src="https://github.com/user-attachments/assets/a5eb0f23-3765-4fa3-93ca-1665d1d51239" />
 
### 👿 트러블 슈팅
1. 테스트 데이터 셋업 시 연관관계 ID 누락 이슈
- 문제: `CommentRepositoryTest` 실행 중 `CommentException: 댓글의 필수 정보가 누락되었습니다.` 에러 발생.
- 원인: `Member` 객체를 생성(`new`)만 하고 영속화(`persist`)하지 않은 상태에서 `getId()`를 호출하여 `null`이 `Comment` 생성자에 전달됨.
- 해결: `em.persist(member)`를 호출하여 영속성 컨텍스트에 저장 및 ID를 생성한 후 `Comment` 엔티티를 생성하도록 수정함.
### 💬 코멘트



