### PR TITLE
feat: 과제 할당 대상자(Assignee) 검증 로직 구현 및 AssignmentManagementPolicy 구조 개선

### DIFF
--- a/src/main/java/econovation/moongtaengi/study/application/assignment/ApproveAssignmentService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/ApproveAssignmentService.java
@@ -23,7 +23,7 @@ public class ApproveAssignmentService {
 
         ProcessInfo processInfo = processInfoProvider.getProcessInfo(assignment.getProcessId());
 
-        assignmentManagementPolicy.validate(processInfo.studyId(), requesterId);
+        assignmentManagementPolicy.validateAuthority(processInfo.studyId(), requesterId);
 
         assignment.approve();
         assignmentRepository.save(assignment);

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/CreateAssignmentService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/CreateAssignmentService.java
@@ -27,7 +27,7 @@ public class CreateAssignmentService {
     public Long createAssignment(CreateAssignmentCommand command) {
         ProcessInfo processInfo = infoProvider.getProcessInfo(command.processId());
 
-        policy.validate(processInfo.studyId(), command.requesterId());
+        policy.validateAllocation(processInfo.studyId(), command.requesterId(), command.assigneeId());
 
         validator.validate(command.processId(), command.assigneeId());
 

--- a/src/main/java/econovation/moongtaengi/study/application/assignment/UpdateAssignmentService.java
+++ b/src/main/java/econovation/moongtaengi/study/application/assignment/UpdateAssignmentService.java
@@ -29,7 +29,7 @@ public class UpdateAssignmentService {
 
         ProcessInfo processInfo = infoProvider.getProcessInfo(assignment.getProcessId());
 
-        policy.validate(processInfo.studyId(), command.requesterId());
+        policy.validateAuthority(processInfo.studyId(), command.requesterId());
 
         assignment.updateDescription(new AssignmentDescription(command.description()));
 

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentErrorCode.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentErrorCode.java
@@ -20,7 +20,9 @@ public enum AssignmentErrorCode implements ErrorCode {
 
     CANNOT_APPROVE_NOT_SUBMITTED(HttpStatus.BAD_REQUEST, "AS_006", "제출되지 않은 과제는 승인할 수 없습니다."),
 
-    UPDATE_ALLOWED_ONLY_IN_WAITING(HttpStatus.BAD_REQUEST, "AS_007","과제 내용은 WAITING 상태에서만 수정 가능합니다.");
+    UPDATE_ALLOWED_ONLY_IN_WAITING(HttpStatus.BAD_REQUEST, "AS_007","과제 내용은 WAITING 상태에서만 수정 가능합니다."),
+
+    INVALID_ASSIGNEE(HttpStatus.BAD_REQUEST, "AS_008", "해당 멤버는 과제 할당 대상이 아닙니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentManagementPolicy.java
+++ b/src/main/java/econovation/moongtaengi/study/domain/assignment/AssignmentManagementPolicy.java
@@ -1,5 +1,7 @@
 package econovation.moongtaengi.study.domain.assignment;
 
 public interface AssignmentManagementPolicy {
-    void validate(Long studyId, Long requesterId);
+    void validateAllocation(Long studyId, Long requesterId, Long assigneeId);
+
+    void validateAuthority(Long studyId, Long requesterId);
 }

--- a/src/main/java/econovation/moongtaengi/study/infra/AssignmentManagementPolicyImpl.java
+++ b/src/main/java/econovation/moongtaengi/study/infra/AssignmentManagementPolicyImpl.java
@@ -1,5 +1,6 @@
 package econovation.moongtaengi.study.infra;
 
+import econovation.moongtaengi.study.domain.StudyException;
 import econovation.moongtaengi.study.domain.StudyMemberRepository;
 import econovation.moongtaengi.study.domain.StudyRole;
 import econovation.moongtaengi.study.domain.assignment.AssignmentErrorCode;
@@ -15,13 +16,27 @@ public class AssignmentManagementPolicyImpl implements AssignmentManagementPolic
     private final StudyMemberRepository studyMemberRepository;
 
     @Override
-    public void validate(Long studyId, Long requesterId) {
+    public void validateAuthority(Long studyId, Long requesterId) {
+        // 1. 방장(관리자) 권한 검증 - 이것만 단독으로 쓰일 때도 있고, 할당 때 재사용되기도 함
         boolean isHost = studyMemberRepository.existsByStudyIdAndMemberIdAndRole(
                 studyId, requesterId, StudyRole.HOST
         );
 
         if (!isHost) {
             throw new AssignmentException(AssignmentErrorCode.NO_MANAGEMENT_PERMISSION);
+        }
+    }
+
+    @Override
+    public void validateAllocation(Long studyId, Long requesterId, Long assigneeId) {
+        validateAuthority(studyId, requesterId);
+
+        boolean isAssigneeMember = studyMemberRepository.existsByStudyIdAndMemberId(
+                studyId, assigneeId
+        );
+
+        if (!isAssigneeMember) {
+            throw new AssignmentException(AssignmentErrorCode.INVALID_ASSIGNEE);
         }
     }
 }

--- a/src/test/java/econovation/moongtaengi/study/application/ApproveAssignmentServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/ApproveAssignmentServiceTest.java
@@ -66,7 +66,7 @@ public class ApproveAssignmentServiceTest {
         //then
         assertThat(assignment.getStatus()).isEqualTo(AssignmentStatus.APPROVED);
 
-        verify(assignmentManagementPolicy).validate(studyId, requesterId);
+        verify(assignmentManagementPolicy).validateAuthority(studyId, requesterId);
     }
 
     @Test
@@ -106,7 +106,7 @@ public class ApproveAssignmentServiceTest {
                 .willReturn(new ProcessInfo(studyId, LocalDate.now(), LocalDate.now()));
 
         willThrow(new AssignmentException(AssignmentErrorCode.NO_MANAGEMENT_PERMISSION))
-                .given(assignmentManagementPolicy).validate(studyId, requesterId);
+                .given(assignmentManagementPolicy).validateAuthority(studyId, requesterId);
 
         //when&then
         assertThatThrownBy(() -> approveAssignmentService.approveAssignment(assignmentId, requesterId))

--- a/src/test/java/econovation/moongtaengi/study/application/CreateAssignmentServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/CreateAssignmentServiceTest.java
@@ -80,7 +80,7 @@ public class CreateAssignmentServiceTest {
         //then
         assertThat(resultId).isEqualTo(1L);
 
-        verify(policy).validate(studyId, command.requesterId());
+        verify(policy).validateAllocation(studyId, command.requesterId(), command.assigneeId());
         verify(validator).validate(command.processId(), command.assigneeId());
         verify(infoProvider).getProcessInfo(command.processId());
 

--- a/src/test/java/econovation/moongtaengi/study/application/UpdateAssignmentServiceTest.java
+++ b/src/test/java/econovation/moongtaengi/study/application/UpdateAssignmentServiceTest.java
@@ -68,7 +68,7 @@ public class UpdateAssignmentServiceTest {
 
             //then
             verify(infoProvider).getProcessInfo(processId);
-            verify(policy).validate(studyId, requesterId);
+            verify(policy).validateAuthority(studyId, requesterId);
             assertThat(assignment.getDescription().getValue()).isEqualTo(newDescriptionValue);
         }
 
@@ -92,6 +92,6 @@ public class UpdateAssignmentServiceTest {
                     .isEqualTo(AssignmentErrorCode.ASSIGNMENT_NOT_FOUND);
 
             verify(infoProvider, never()).getProcessInfo(any());
-            verify(policy, never()).validate(any(), any());
+            verify(policy, never()).validateAuthority(any(), any());
         }
 }

--- a/src/test/java/econovation/moongtaengi/study/infra/AssignmentManagementPolicyImplTest.java
+++ b/src/test/java/econovation/moongtaengi/study/infra/AssignmentManagementPolicyImplTest.java
@@ -24,7 +24,7 @@ public class AssignmentManagementPolicyImplTest {
     private AssignmentManagementPolicyImpl policy;
 
     @Test
-    @DisplayName("권한이 없는 멤버가 요청하면 예외가 발생한다")
+    @DisplayName("관리 권한 검증(validateAuthority)을 할 때 방장이 아니면 예외가 발생한다")
     void 권한_검증_실패() {
         //given
         Long studyId = 1L;
@@ -35,24 +35,69 @@ public class AssignmentManagementPolicyImplTest {
                 .willReturn(false);
 
         //when&then
-        assertThatThrownBy(() -> policy.validate(studyId, requesterId))
+        assertThatThrownBy(() -> policy.validateAuthority(studyId, requesterId))
                 .isInstanceOf(AssignmentException.class)
                 .extracting("errorCode")
                 .isEqualTo(AssignmentErrorCode.NO_MANAGEMENT_PERMISSION);
     }
 
     @Test
-    @DisplayName("권한이 있는 멤버가 요청하면 통과한다")
-    void 권한_검증_성공() {
+    @DisplayName("할당 검증(validateAllocation)을 할 때 방장 권한이 없으면, 멤버 검증 로직은 실행되지 않고 바로 예외가 터진다")
+    void 할당_검증_실패_권한없음() {
+        //given
+        Long studyId = 1L;
+        Long requesterId = 99L;
+        Long assigneeId = 3L;
+
+        given(studyMemberRepository.existsByStudyIdAndMemberIdAndRole(
+                studyId, requesterId, StudyRole.HOST))
+                .willReturn(false);
+
+        //when&then
+        assertThatThrownBy(() -> policy.validateAllocation(studyId, requesterId, assigneeId))
+                .isInstanceOf(AssignmentException.class)
+                .extracting("errorCode")
+                .isEqualTo(AssignmentErrorCode.NO_MANAGEMENT_PERMISSION);
+    }
+
+    @Test
+    @DisplayName("할당 검증을 할 때 방장은 맞지만, 대상자가 스터디원이 아니면 예외가 발생한다")
+    void 할당_검증_실패_대상자아님() {
         //given
         Long studyId = 1L;
         Long requesterId = 10L;
+        Long assigneeId = 999L;
 
         given(studyMemberRepository.existsByStudyIdAndMemberIdAndRole(
                 studyId, requesterId, StudyRole.HOST))
                 .willReturn(true);
+        given(studyMemberRepository.existsByStudyIdAndMemberId(
+                studyId, assigneeId))
+                .willReturn(false);
 
         //when&then
-        assertDoesNotThrow(() -> policy.validate(studyId, requesterId));
+        assertThatThrownBy(() -> policy.validateAllocation(studyId, requesterId, assigneeId))
+                .isInstanceOf(AssignmentException.class)
+                .extracting("errorCode")
+                .isEqualTo(AssignmentErrorCode.INVALID_ASSIGNEE);
+    }
+
+    @Test
+    @DisplayName("할당 검증을 할 때 방장이고 대상자도 멤버라면 성공한다")
+    void 할당_검증_성공() {
+        //given
+        Long studyId = 1L;
+        Long requesterId = 10L;
+        Long assigneeId = 11L;
+
+        given(studyMemberRepository.existsByStudyIdAndMemberIdAndRole(
+                studyId, requesterId, StudyRole.HOST))
+                .willReturn(true);
+        given(studyMemberRepository.existsByStudyIdAndMemberId(
+                studyId, assigneeId))
+                .willReturn(true);
+
+        //when&then
+        assertDoesNotThrow(() -> policy.validateAllocation(studyId, requesterId, assigneeId));
     }
 }


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📄 관련 이슈
<!-- 이슈번호: close #334 -->

### 🧑‍💻 구현한 내용
1. 과제 관리 정책 구조 개선
   - AssignmentManagementPolicy 인터페이스 메서드 분리
      - validateAllocation(studyId, requesterId, assigneeId): 과제 생성 및 배정 시 사용. 요청자의 관리 권한(방장 여부)과 할당 대상자의 스터디 참여 여부를 검증.
      - validateAuthority(studyId, requesterId): 과제 수정 및 삭제 시 사용. 이미 할당된 과제를 관리하는 상황이므로 요청자의 관리 권한만 검증.
   - 구현체(Impl) 내 로직 재사용
      - validateAllocation 내부에서 validateAuthority를 호출하는 체이닝 구조를 적용하여 권한 검증 로직의 중복을 제거.

2. 할당 대상자 검증 로직 구현
   - StudyMemberRepository를 연동하여 실제 DB 데이터를 기반으로 assigneeId가 해당 스터디의 멤버인지 확인(existsByStudyIdAndMemberId).
   - 검증 실패 시 StudyException이 아닌 AssignmentErrorCode.INVALID_ASSIGNEE를 발생시켜 도메인 간 의존성을 분리.

3. 서비스 계층 적용
   - CreateAssignmentService: 과제 배정 정책(validateAllocation)을 적용하여 스터디 멤버가 아닌 사람에게 과제가 생성되는 것을 방지
   - UpdateAssignmentService: 관리 권한 정책(validateAuthority)을 적용하여 assignee와 관계없이 방장이 과제 내용을 수정할 수 있도록 변경

4. 테스트 코드
   - AssignmentManagementPolicyImplTest 리팩토링
      - 권한 없음(실패), 대상자 아님(실패), 성공 케이스를 분리하여 추가.
### 🧪 테스트 결과
- [x] 테스트 코드 모두 통과했습니다! 
- [x] 포스트맨을 이용한 테스트
<img width="283" height="183" alt="image" src="https://github.com/user-attachments/assets/fcae7a8e-898f-468a-b882-f54996e5bdb2" />
<img width="315" height="101" alt="image" src="https://github.com/user-attachments/assets/dcca4fb2-2e40-4553-b6e5-c3414b79766c" />
 
### 👿 트러블 슈팅
**트러블 슈팅: Mockito UnnecessaryStubbingException 해결**
1. 문제 상황
   - AssignmentManagementPolicy의 "권한 검증 실패" 케이스를 테스트하던 중 UnnecessaryStubbingException 발생.

2. 원인 분석
   - validateAuthority에서 예외(throw)가 발생하면 메서드 실행이 즉시 중단되므로, 뒤따르는 멤버 검증 로직은 실행되지 않음 (Unreachable).
   - MockitoExtension의 Strict Mode는 실행되지 않는 코드에 대한 Stubbing(given)을 감지하고, 이를 "불필요한 코드"로 간주하여 에러를 발생시킴.

3. 해결
   - 예외가 발생하는 실패 케이스 테스트에서는 예외 발생 지점 이후의 로직에 대한 Stubbing을 제거하여 테스트 통과 및 코드 품질 개선.
### 💬 코멘트



